### PR TITLE
Remove scss extensions from @material/mdc-* imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
           "button",
           "card",
           "fab",
+          "line-ripple",
           "ripple",
           "top-app-bar",
           "infrastructure"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
           "button",
           "card",
           "fab",
+          "floating-label",
           "line-ripple",
           "ripple",
           "top-app-bar",

--- a/packages/button/index.scss
+++ b/packages/button/index.scss
@@ -1,1 +1,1 @@
-@import "@material/button/mdc-button.scss";
+@import "@material/button/mdc-button";

--- a/packages/card/index.scss
+++ b/packages/card/index.scss
@@ -1,1 +1,1 @@
-@import "@material/card/mdc-card.scss";
+@import "@material/card/mdc-card";

--- a/packages/floating-label/index.scss
+++ b/packages/floating-label/index.scss
@@ -1,1 +1,1 @@
-@import "@material/floating-label/mdc-floating-label.scss";
+@import "@material/floating-label/mdc-floating-label";

--- a/packages/line-ripple/index.scss
+++ b/packages/line-ripple/index.scss
@@ -1,1 +1,1 @@
-@import "@material/line-ripple/mdc-line-ripple.scss";
+@import "@material/line-ripple/mdc-line-ripple";


### PR DESCRIPTION
Hi, I would like to help with material-components-web-react.

The sass imports are handy, but I was having trouble importing SCSS from Button. I needed to directly import the css from the non-react package, basically duplicating the intent of the index.scss of react-button:
<img width="756" alt="image" src="https://user-images.githubusercontent.com/5633265/40340949-168bf88c-5d50-11e8-99e0-17d02cc4c9c4.png">


When I looked at [the icon component sass import](https://github.com/material-components/material-components-web-react/blob/a45c75a1fd8bc7b83fbe0775fc629c928bb1df0f/packages/material-icon/index.scss#L2) I noticed that it didn't have an extension. Going into node_modules and removing it from the button index.scss file fixed the issue and allowed me to just import the button styles with `@import "@material/button/mdc-button";`, so perhaps this was just an oversight.

I've never used learn before, so I may need help figuring out how to contribute to this codebase :/
