### PR TITLE
fix(ripple): Trigger on key events

### DIFF
--- a/packages/ripple/index.js
+++ b/packages/ripple/index.js
@@ -68,16 +68,6 @@ const withRipple = (WrappedComponent) => {
       return classnames(Array.from(classList), wrappedCompClasses);
     }
 
-    handleFocus = (e) => {
-      this.props.onFocus(e);
-      this.foundation_.focusHandler_(e);
-    }
-
-    handleBlur = (e) => {
-      this.props.onBlur(e);
-      this.foundation_.blurHandler_(e);
-    }
-
     handleMouseDown = (e) => {
       this.props.onMouseDown(e);
       this.activateRipple(e);
@@ -137,8 +127,6 @@ const withRipple = (WrappedComponent) => {
         unbounded,
         style,
         className,
-        onFocus,
-        onBlur,
         onMouseDown,
         onMouseUp,
         onTouchStart,
@@ -151,8 +139,6 @@ const withRipple = (WrappedComponent) => {
       } = this.props;
 
       const updatedProps = Object.assign(otherProps, {
-        onFocus: this.handleFocus,
-        onBlur: this.handleBlur,
         onMouseDown: this.handleMouseDown,
         onMouseUp: this.handleMouseUp,
         onTouchStart: this.handleTouchStart,
@@ -174,8 +160,6 @@ const withRipple = (WrappedComponent) => {
     disabled: PropTypes.bool,
     style: PropTypes.object,
     className: PropTypes.string,
-    onFocus: PropTypes.func,
-    onBlur: PropTypes.func,
     onMouseDown: PropTypes.func,
     onMouseUp: PropTypes.func,
     onTouchStart: PropTypes.func,
@@ -189,8 +173,6 @@ const withRipple = (WrappedComponent) => {
     disabled: false,
     style: {},
     className: '',
-    onFocus: () => {},
-    onBlur: () => {},
     onMouseDown: () => {},
     onMouseUp: () => {},
     onTouchStart: () => {},

--- a/packages/ripple/index.js
+++ b/packages/ripple/index.js
@@ -35,7 +35,7 @@ const withRipple = (WrappedComponent) => {
 
     createAdapter_ = (instance) => {
       const MATCHES = [
-        'webkitMatchesSelector', 'msMatchesSelector', 'matches'
+        'webkitMatchesSelector', 'msMatchesSelector', 'matches',
       ].filter((p) => p in HTMLElement.prototype).pop();
 
       return {

--- a/packages/ripple/index.js
+++ b/packages/ripple/index.js
@@ -34,9 +34,7 @@ const withRipple = (WrappedComponent) => {
     }
 
     createAdapter_ = (instance) => {
-      const MATCHES = [
-        'webkitMatchesSelector', 'msMatchesSelector', 'matches',
-      ].filter((p) => p in HTMLElement.prototype).pop();
+      const MATCHES = util.getMatchesProperty(HTMLElement.prototype);
 
       return {
         browserSupportsCssVars: () => util.supportsCssVariables(window),

--- a/test/unit/ripple/index.test.js
+++ b/test/unit/ripple/index.test.js
@@ -48,13 +48,13 @@ test('mouseDown event triggers activateRipple', () => {
   td.verify(mouseDownHandler(td.matchers.isA(Object)), {times: 1});
 });
 
-test('mouseUp event does not trigger activateRipple', () => {
+test('mouseUp event triggers deactivateRipple', () => {
   const mouseUpHandler = td.func();
   const wrapper = mount(<DivRipple onMouseUp={mouseUpHandler}/>);
   const foundation = wrapper.instance().foundation_;
   foundation.activate = td.func();
   wrapper.simulate('mouseUp');
-  td.verify(foundation.activate(td.matchers.isA(Object)), {times: 0});
+  td.verify(foundation.deactivate(td.matchers.isA(Object)), {times: 1});
   td.verify(mouseUpHandler(td.matchers.isA(Object)), {times: 1});
 });
 
@@ -76,6 +76,16 @@ test('touchStart event triggers activateRipple with no onTouchStart handler', ()
   td.verify(foundation.activate(td.matchers.isA(Object)), {times: 1});
 });
 
+test('touchEnd event triggers deactivateRipple', () => {
+  const touchEndHandler = td.func();
+  const wrapper = mount(<DivRipple ontouchEnd={touchEndHandler}/>);
+  const foundation = wrapper.instance().foundation_;
+  foundation.activate = td.func();
+  wrapper.simulate('touchEnd');
+  td.verify(foundation.deactivate(td.matchers.isA(Object)), {times: 1});
+  td.verify(touchEndHandler(td.matchers.isA(Object)), {times: 1});
+});
+
 test('keyDown event triggers activateRipple', () => {
   const keyDownHandler = td.func();
   const wrapper = mount(<DivRipple onKeyDown={keyDownHandler}/>);
@@ -92,6 +102,16 @@ test('keyDown event triggers activateRipple with no onKeyDown handler', () => {
   foundation.activate = td.func();
   wrapper.simulate('keyDown');
   td.verify(foundation.activate(td.matchers.isA(Object)), {times: 1});
+});
+
+test('keyUp event triggers deactivateRipple', () => {
+  const keyUpHandler = td.func();
+  const wrapper = mount(<DivRipple onkeyUp={keyUpHandler}/>);
+  const foundation = wrapper.instance().foundation_;
+  foundation.activate = td.func();
+  wrapper.simulate('keyUp');
+  td.verify(foundation.deactivate(td.matchers.isA(Object)), {times: 1});
+  td.verify(keyUpHandler(td.matchers.isA(Object)), {times: 1});
 });
 
 test('#adapter.isUnbounded returns true is prop is set', () => {

--- a/test/unit/ripple/index.test.js
+++ b/test/unit/ripple/index.test.js
@@ -52,10 +52,18 @@ test('mouseUp event triggers deactivateRipple', () => {
   const mouseUpHandler = td.func();
   const wrapper = mount(<DivRipple onMouseUp={mouseUpHandler}/>);
   const foundation = wrapper.instance().foundation_;
-  foundation.activate = td.func();
+  foundation.deactivate = td.func();
   wrapper.simulate('mouseUp');
   td.verify(foundation.deactivate(td.matchers.isA(Object)), {times: 1});
   td.verify(mouseUpHandler(td.matchers.isA(Object)), {times: 1});
+});
+
+test('mouseUp event triggers deactivateRipple with no onMouseUp handler', () => {
+  const wrapper = mount(<DivRipple />);
+  const foundation = wrapper.instance().foundation_;
+  foundation.deactivate = td.func();
+  wrapper.simulate('mouseUp');
+  td.verify(foundation.deactivate(td.matchers.isA(Object)), {times: 1});
 });
 
 test('touchStart event triggers activateRipple', () => {
@@ -78,12 +86,20 @@ test('touchStart event triggers activateRipple with no onTouchStart handler', ()
 
 test('touchEnd event triggers deactivateRipple', () => {
   const touchEndHandler = td.func();
-  const wrapper = mount(<DivRipple ontouchEnd={touchEndHandler}/>);
+  const wrapper = mount(<DivRipple onTouchEnd={touchEndHandler}/>);
   const foundation = wrapper.instance().foundation_;
-  foundation.activate = td.func();
+  foundation.deactivate = td.func();
   wrapper.simulate('touchEnd');
   td.verify(foundation.deactivate(td.matchers.isA(Object)), {times: 1});
   td.verify(touchEndHandler(td.matchers.isA(Object)), {times: 1});
+});
+
+test('touchEnd event triggers deactivateRipple with no onTouchEnd handler', () => {
+  const wrapper = mount(<DivRipple />);
+  const foundation = wrapper.instance().foundation_;
+  foundation.deactivate = td.func();
+  wrapper.simulate('touchEnd');
+  td.verify(foundation.deactivate(td.matchers.isA(Object)), {times: 1});
 });
 
 test('keyDown event triggers activateRipple', () => {
@@ -106,12 +122,20 @@ test('keyDown event triggers activateRipple with no onKeyDown handler', () => {
 
 test('keyUp event triggers deactivateRipple', () => {
   const keyUpHandler = td.func();
-  const wrapper = mount(<DivRipple onkeyUp={keyUpHandler}/>);
+  const wrapper = mount(<DivRipple onKeyUp={keyUpHandler}/>);
   const foundation = wrapper.instance().foundation_;
-  foundation.activate = td.func();
+  foundation.deactivate = td.func();
   wrapper.simulate('keyUp');
   td.verify(foundation.deactivate(td.matchers.isA(Object)), {times: 1});
   td.verify(keyUpHandler(td.matchers.isA(Object)), {times: 1});
+});
+
+test('keyUp event triggers deactivateRipple with no onKeyUp handler', () => {
+  const wrapper = mount(<DivRipple />);
+  const foundation = wrapper.instance().foundation_;
+  foundation.deactivate = td.func();
+  wrapper.simulate('keyUp');
+  td.verify(foundation.deactivate(td.matchers.isA(Object)), {times: 1});
 });
 
 test('#adapter.isUnbounded returns true is prop is set', () => {
@@ -122,19 +146,6 @@ test('#adapter.isUnbounded returns true is prop is set', () => {
 test('#adapter.isUnbounded returns false prop is not set', () => {
   const wrapper = mount(<DivRipple />);
   assert.isFalse(wrapper.instance().foundation_.adapter_.isUnbounded());
-});
-
-test('#adapter.isSurfaceActive returns true onMouseDown event', () => {
-  const wrapper = mount(<DivRipple />);
-  wrapper.simulate('mouseDown');
-  assert.isTrue(wrapper.instance().foundation_.adapter_.isSurfaceActive());
-});
-
-test('#adapter.isSurfaceActive returns false after onMouseUp event ', () => {
-  const wrapper = mount(<DivRipple />);
-  wrapper.simulate('mouseDown');
-  wrapper.simulate('mouseUp');
-  assert.isFalse(wrapper.instance().foundation_.adapter_.isSurfaceActive());
 });
 
 test('#adapter.isSurfaceDisabled returns true is prop is set', () => {


### PR DESCRIPTION
Fixes #41.

Re-implement the `isSurfaceActive()` adapter method to check for active state directly on the ripple surface element, instead of creating and updating an `isActivated` state variable. 
Wire up the appropriate event handlers to call `deactivate(e)` in the foundation.