### PR TITLE
fix(infrastructure): fixed npm run build error for empty package directories

### DIFF
--- a/packages/webpack.config.js
+++ b/packages/webpack.config.js
@@ -20,10 +20,12 @@ const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const isDirectory = (source) => lstatSync(source).isDirectory();
+const containsJsFile = (source) => readdirSync(source).some(file => path.parse(file).ext === '.js');
+
 const getChunks = (source) =>
   readdirSync(source)
     .map((filename) => path.join(source, filename))
-    .filter(isDirectory)
+    .filter((source) => isDirectory(source) && containsJsFile(source))
     .map((directoryPath) => directoryPath.replace('packages\/', ''));
 
 const chunks = getChunks('./packages');

--- a/packages/webpack.config.js
+++ b/packages/webpack.config.js
@@ -20,7 +20,7 @@ const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const isDirectory = (source) => lstatSync(source).isDirectory();
-const containsJsFile = (source) => readdirSync(source).some(file => path.parse(file).ext === '.js');
+const containsJsFile = (source) => readdirSync(source).some((file) => path.extname(file) === '.js');
 
 const getChunks = (source) =>
   readdirSync(source)


### PR DESCRIPTION
fixes https://github.com/material-components/material-components-web-react/issues/82

Error occurs when an empty directory exists in /packages ie. Chips.