### PR TITLE
docs: build-css script, edit for output directory.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,7 +54,7 @@ with:
 
 ```js
 "scripts": {
-  "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules ./src/App.scss -o ./src/App.css",
+  "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules ./src/App.scss -o ./src",
   "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules --watch ./src/App.scss ./src/App.css",
   "start-js": "react-scripts start",
   "start": "npm-run-all -p watch-css start-js",


### PR DESCRIPTION
modified:   docs/getting-started.md
The -o option of node-sass-chokidar is for output directory. For import './App.css' to work in App.js, in build-css script it should be -o ./src otherwise a directory named App.css is created an App.css file is created inside it.