### PR TITLE
Fix getting-started typo

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ If you want to use the compiled CSS and not customize any colors, text, etc. you
 
 Most likely you'll want to start using the [Sass mixins](https://github.com/material-components/material-components-web/blob/master/docs/code/architecture.md#sass) to customize your app. There are a few ways to achieve this. `create-react-app` does have a [recommended approach](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-a-css-preprocessor-sass-less-etc), which we also recommend.
 
-The following is an alternate version of the `create-react-app` approach. The difference being all the your `node_modules` imports will go into `./src/App.scss`. First install `node-sass-chokidar`:
+The following is an alternate version of the `create-react-app` approach. The difference being all the `node_modules` imports will go into `./src/App.scss`. First install `node-sass-chokidar`:
 
 ```
 npm install -D node-sass-chokidar npm-run-all


### PR DESCRIPTION
Fixed a small typo.

![inkedscreenshot-2018-6-25 material-components material-components-web-react_li](https://user-images.githubusercontent.com/22499864/41838204-617f083c-787d-11e8-9301-93d31637e478.jpg)

From "The difference being all the your node_modules imports will..."

To "The difference being all the node_modules imports will..."
