### PR TITLE
fix(infrastructure): add the es5 @material/package/dist/mdc.package to externals

### DIFF
--- a/packages/webpack.config.js
+++ b/packages/webpack.config.js
@@ -69,6 +69,7 @@ function getCommonWebpackParams(entryPath, chunk, {isCss, modules}) {
 }
 
 function getMaterialExternals() {
+  const dashedToCamel = (name) => name.replace(/-(\w)/g, (_, v) => v.toUpperCase());
   const externals = {};
   [
     'base',
@@ -86,7 +87,12 @@ function getMaterialExternals() {
     'textfield',
     'top-app-bar',
     'typography',
-  ].forEach((name) => externals[`@material/${name}`] = `@material/${name}`);
+  ].forEach((name) => {
+    // this can be reverted when we change back to @material/foo-package-filename
+    // https://github.com/material-components/material-components-web/pull/3245
+    const fileName = `@material/${name}/dist/mdc.${dashedToCamel(name)}`;
+    externals[fileName] = fileName;
+  });
   return externals;
 }
 


### PR DESCRIPTION
When we converted all our @ material package imports to point to the es5 files instead of the es6, this changed the filepaths. We also need to update the webpack external filepaths so it is not included in bundled javascript file.