### PR TITLE
docs: remove obsolete Style section in text-field

### DIFF
--- a/packages/text-field/README.md
+++ b/packages/text-field/README.md
@@ -95,18 +95,6 @@ value | Number/String | Value of the input.
 >NOTE: the `<Input>` component will receive all properties that a standard `<input>` accepts.
 
 
-## Styles
-
-To style [Notched Outline](../notched-outline), [Floating Label](../floating-label), and [Line Ripple](../line-ripple) correctly, please include the Sass imports along with the Text Field sass imports. For reference your Sass file should include imports like so:
-
-```scss
-@import "@material/react-floating-label/index.scss";
-@import "@material/react-line-ripple/index.scss";
-@import "@material/react-notched-outline/index.scss";
-
-@import "@material/react-text-field/index.scss";
-```
-
 ### Sass Mixins
 
 Sass mixins may be available to customize various aspects of the Components. Please refer to the


### PR DESCRIPTION
Documentation states that it Sass imports should be included for styling floating label, line ripple and notched outline. However, they are already imported when `mdc-textfield` styles are imported (https://github.com/material-components/material-components-web/blob/master/packages/mdc-textfield/mdc-text-field.scss#L24-L26)  from  text-field `index.scss` (https://github.com/material-components/material-components-web-react/blob/master/packages/text-field/index.scss#L25).