### PR TITLE
fix: tab indicator sliding animation broken

### DIFF
--- a/packages/tab-indicator/index.js
+++ b/packages/tab-indicator/index.js
@@ -32,10 +32,6 @@ import {
 export default class TabIndicator extends Component {
   tabIndicatorElement_ = React.createRef();
 
-  state = {
-    classList: new Set(),
-  };
-
   componentDidMount() {
     if (this.props.fade) {
       this.foundation_ = new MDCFadingTabIndicatorFoundation(this.adapter);
@@ -64,9 +60,8 @@ export default class TabIndicator extends Component {
   }
 
   get classes() {
-    const {classList} = this.state;
     const {className, fade} = this.props;
-    return classnames('mdc-tab-indicator', Array.from(classList), className, {
+    return classnames('mdc-tab-indicator', className, {
       'mdc-tab-indicator--fade': fade,
     });
   }
@@ -82,16 +77,15 @@ export default class TabIndicator extends Component {
   get adapter() {
     return {
       addClass: (className) => {
-        // const {classList} = this.state;
-        // classList.add(className);
-        // this.setState({classList});
+        // since the sliding indicator depends on the FLIP method,
+        // our regular pattern of managing classes does not work here.
+        // setState is async, which does not work well with the FLIP method
+        // without a requestAnimationFrame, which was done in this PR:
+        // https://github.com/material-components/material-components-web/pull/3337/files#diff-683d792d28dad99754294121e1afbfb5L62
         this.tabIndicatorElement_.current.classList.add(className);
         this.forceUpdate();
       },
       removeClass: (className) => {
-        // const {classList} = this.state;
-        // classList.delete(className);
-        // this.setState({classList});
         this.tabIndicatorElement_.current.classList.remove(className);
         this.forceUpdate();
       },
@@ -101,7 +95,7 @@ export default class TabIndicator extends Component {
       setContentStyleProperty: (prop, value) => {
         const contentElement = this.getNativeContentElement();
         if (!contentElement) return;
-        contentElement.style.setProperty(prop, value)
+        contentElement.style[prop] = value;
       },
     };
   }

--- a/packages/tab-indicator/index.js
+++ b/packages/tab-indicator/index.js
@@ -77,7 +77,7 @@ export default class TabIndicator extends Component {
   get adapter() {
     return {
       addClass: (className) => {
-        // if (!this.tabIndicatorElement_.current) return;
+        if (!this.tabIndicatorElement_.current) return;
         // since the sliding indicator depends on the FLIP method,
         // our regular pattern of managing classes does not work here.
         // setState is async, which does not work well with the FLIP method
@@ -88,7 +88,7 @@ export default class TabIndicator extends Component {
         this.forceUpdate();
       },
       removeClass: (className) => {
-        // if (!this.tabIndicatorElement_.current) return;
+        if (!this.tabIndicatorElement_.current) return;
         this.tabIndicatorElement_.current.classList.remove(className);
         this.forceUpdate();
       },

--- a/packages/tab-indicator/index.js
+++ b/packages/tab-indicator/index.js
@@ -77,15 +77,18 @@ export default class TabIndicator extends Component {
   get adapter() {
     return {
       addClass: (className) => {
+        // if (!this.tabIndicatorElement_.current) return;
         // since the sliding indicator depends on the FLIP method,
         // our regular pattern of managing classes does not work here.
         // setState is async, which does not work well with the FLIP method
         // without a requestAnimationFrame, which was done in this PR:
-        // https://github.com/material-components/material-components-web/pull/3337/files#diff-683d792d28dad99754294121e1afbfb5L62
+        // https://github.com/material-components
+        // /material-components-web/pull/3337/files#diff-683d792d28dad99754294121e1afbfb5L62
         this.tabIndicatorElement_.current.classList.add(className);
         this.forceUpdate();
       },
       removeClass: (className) => {
+        // if (!this.tabIndicatorElement_.current) return;
         this.tabIndicatorElement_.current.classList.remove(className);
         this.forceUpdate();
       },

--- a/packages/tab-indicator/index.js
+++ b/packages/tab-indicator/index.js
@@ -82,14 +82,18 @@ export default class TabIndicator extends Component {
   get adapter() {
     return {
       addClass: (className) => {
-        const {classList} = this.state;
-        classList.add(className);
-        this.setState({classList});
+        // const {classList} = this.state;
+        // classList.add(className);
+        // this.setState({classList});
+        this.tabIndicatorElement_.current.classList.add(className);
+        this.forceUpdate();
       },
       removeClass: (className) => {
-        const {classList} = this.state;
-        classList.delete(className);
-        this.setState({classList});
+        // const {classList} = this.state;
+        // classList.delete(className);
+        // this.setState({classList});
+        this.tabIndicatorElement_.current.classList.remove(className);
+        this.forceUpdate();
       },
       computeContentClientRect: this.computeContentClientRect,
       // setContentStyleProperty was using setState, but due to the method's
@@ -97,7 +101,7 @@ export default class TabIndicator extends Component {
       setContentStyleProperty: (prop, value) => {
         const contentElement = this.getNativeContentElement();
         if (!contentElement) return;
-        contentElement.style[prop] = value;
+        contentElement.style.setProperty(prop, value)
       },
     };
   }

--- a/test/unit/tab-indicator/index.test.js
+++ b/test/unit/tab-indicator/index.test.js
@@ -19,8 +19,10 @@ test('adds the fade class if props.fade is true', () => {
 });
 
 test('adds the active class if props.active is true', () => {
-  const wrapper = shallow(<TabIndicator active />);
-  assert.isTrue(wrapper.hasClass('mdc-tab-indicator--active'));
+  // need to mount,
+  // since classList is now applied by ref
+  const wrapper = mount(<TabIndicator active />);
+  assert.isTrue(wrapper.getDOMNode().classList.contains('mdc-tab-indicator--active'));
 });
 
 test('adds the icon class to the content element if props.icon is true', () => {
@@ -36,7 +38,7 @@ test('adds the underline class to the content element by default', () => {
 });
 
 test('if props.active changes from true to false, it calls deactivate', () => {
-  const wrapper = shallow(<TabIndicator active />);
+  const wrapper = mount(<TabIndicator active />);
   wrapper.instance().foundation_.deactivate = td.func();
   wrapper.setProps({active: false});
   td.verify(wrapper.instance().foundation_.deactivate(), {times: 1});
@@ -50,17 +52,17 @@ test('if props.active changes from false to true, it calls activate', () => {
   td.verify(wrapper.instance().foundation_.activate(previousIndicatorClientRect), {times: 1});
 });
 
-test('#adapter.addClass updates state.classList', () => {
-  const wrapper = shallow(<TabIndicator />);
+test('#adapter.addClass adds to dom element classList', () => {
+  const wrapper = mount(<TabIndicator />);
   wrapper.instance().adapter.addClass('meow-class');
-  assert.isTrue(wrapper.state().classList.has('meow-class'));
+  assert.isTrue(wrapper.getDOMNode().classList.contains('meow-class'));
 });
 
-test('#adapter.removeClass updates state.classList', () => {
-  const wrapper = shallow(<TabIndicator />);
-  wrapper.setState({classList: new Set(['meow-class'])});
+test('#adapter.removeClass removes from dom element classList', () => {
+  const wrapper = mount(<TabIndicator />);
+  wrapper.getDOMNode().classList.add('meow-class');
   wrapper.instance().adapter.removeClass('meow-class');
-  assert.isFalse(wrapper.state().classList.has('meow-class'));
+  assert.isFalse(wrapper.getDOMNode().classList.contains('meow-class'));
 });
 
 test('#adapter.setContentStyleProperty sets the style property on the contentElement', () => {


### PR DESCRIPTION
After the update to MDC Web 0.39.x, the tab indicator's default sliding animation stopped working. The cause was from removing the requestAnimationFrame from MDC Web code. Since the React component's classes were originally managed by setState, which is async, this didn't give the browser enough time to apply the classes. This ultimately broke the animation. 

This fix is to use the DOM's classList, which is synchronous. This requires us to use a `forceUpdate`, which is not used in our codebase. But since this animation requires synchronous class management, we need to forceUpdate after adding/removing classes.