### PR TITLE
fix(list): selectedIndex 0 isn't working

### DIFF
--- a/packages/list/index.js
+++ b/packages/list/index.js
@@ -50,7 +50,7 @@ export default class List extends Component {
     this.foundation_.setSingleSelection(singleSelection);
     this.foundation_.setWrapFocus(wrapFocus);
     this.foundation_.setVerticalOrientation(this.props[ARIA_ORIENTATION] === VERTICAL);
-    if (selectedIndex) {
+    if (Number.isInteger(selectedIndex)) {
       this.foundation_.setSelectedIndex(selectedIndex);
     } else {
       const id = this.getListItemIdFromIndex_(0);

--- a/packages/list/index.js
+++ b/packages/list/index.js
@@ -50,7 +50,7 @@ export default class List extends Component {
     this.foundation_.setSingleSelection(singleSelection);
     this.foundation_.setWrapFocus(wrapFocus);
     this.foundation_.setVerticalOrientation(this.props[ARIA_ORIENTATION] === VERTICAL);
-    if (Number.isInteger(selectedIndex)) {
+    if (typeof selectedIndex === 'number' && !isNaN(selectedIndex)) {
       this.foundation_.setSelectedIndex(selectedIndex);
     } else {
       const id = this.getListItemIdFromIndex_(0);

--- a/test/unit/list/index.test.js
+++ b/test/unit/list/index.test.js
@@ -333,3 +333,16 @@ test('on keydown calls #foudation.handleFocusOut', () => {
   wrapper.simulate('blur', evt);
   td.verify(wrapper.instance().foundation_.handleFocusOut(td.matchers.isA(Object), 1), {times: 1});
 });
+
+test('Test whether first item is selected when selectedIndex is 0.', () => {
+  const wrapper = mount(
+    <List selectedIndex={0}>
+      <ListItem id='item1' />
+      <ListItem id='item2' />
+      <ListItem id='item3' />
+    </List>
+  );
+  assert.equal(wrapper.state().listItemAttributes['item1'].tabIndex, 0);
+  assert.equal(wrapper.state().listItemAttributes['item2'].tabIndex, -1);
+  assert.equal(wrapper.state().listItemAttributes['item3'].tabIndex, -1);
+});

--- a/test/unit/list/index.test.js
+++ b/test/unit/list/index.test.js
@@ -342,7 +342,5 @@ test('Test whether first item is selected when selectedIndex is 0.', () => {
       <ListItem id='item3' />
     </List>
   );
-  assert.equal(wrapper.state().listItemAttributes['item1'].tabIndex, 0);
-  assert.equal(wrapper.state().listItemAttributes['item2'].tabIndex, -1);
-  assert.equal(wrapper.state().listItemAttributes['item3'].tabIndex, -1);
+  assert.isTrue(wrapper.state().listItemAttributes['item1']['aria-selected']);
 });


### PR DESCRIPTION
As you know, 0 is replaced with false in javascript.
When selectedIndex is 0, setSelectedIndex is not executed.
So I add check code "Number.isInteger".