### PR TITLE
docs(card-media): update readme with aspect ratio requirement

### DIFF
--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -95,7 +95,7 @@ import Card, {CardPrimaryContent} from '@material/react-card';
 
 ### CardMedia
 
-This component is a container for an image on the card. Optionally, any children of the `<CardMedia>` component is wrapped with an element with the className `.mdc-card__media-content`. CardMedia requires that you have an aspect ratio of either `square` or `wide` in order to display.
+This component is a container for an image on the card. Optionally, any children of the `<CardMedia>` component is wrapped with an element with the className `.mdc-card__media-content`. In order for your image to display, CardMedia requires that you have an aspect ratio of either `square` or `wide`.
 
 ```js
 import {CardMedia} from '@material/react-card';

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -95,12 +95,12 @@ import Card, {CardPrimaryContent} from '@material/react-card';
 
 ### CardMedia
 
-This component is a container for an image on the card. Optionally, any children of the `<CardMedia>` component is wrapped with an element with the className `.mdc-card__media-content`.
+This component is a container for an image on the card. Optionally, any children of the `<CardMedia>` component is wrapped with an element with the className `.mdc-card__media-content`. CardMedia requires that you have an aspect ratio of either `square` or `wide` in order to display.
 
 ```js
 import {CardMedia} from '@material/react-card';
 
-<CardMedia imageUrl='./my/fancy/image.png'>
+<CardMedia square imageUrl='./my/fancy/image.png'>
   <span>Fancy Image</span>
 </CardMedia>
 ```


### PR DESCRIPTION
Hello, have been enjoying this awesome library you have here. As @moog16 had stated in issue #503 a `<CardMedia>` component must have an aspect ratio passed into it in order for it to display. I want to clarify the documentation to reflect that important detail. Thanks! 😃 