### PR TITLE
docs: update broken look to ../screenshot-tests.md

### DIFF
--- a/docs/contributions/running-tests.md
+++ b/docs/contributions/running-tests.md
@@ -7,7 +7,7 @@ If you need help updating, please see [NVM](https://github.com/creationix/nvm#in
 
 ## Screenshot Tests
 
-Please refer to [screenshot tests](../screnshot-tests.md).
+Please refer to [screenshot tests](../screenshot-tests.md).
 
 ## Unit Tests
 


### PR DESCRIPTION
[running-tests.md](https://github.com/material-components/material-components-web-react/blob/master/docs/contributions/running-tests.md) referenced screenshot tests, but the filename was misspelled. 

---

I signed it.