### PR TITLE
fix(infrastructure): condense webpack configuration build step into one json file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ If you're using an older version (v1) of `create-react-app`, please refer to our
 
 #### Step 1: Install create-react-app
 
+> _NOTE:_ all npm commands can be replaced with yarn
+
 Install `create-react-app`:
 
 ```
@@ -68,7 +70,14 @@ cd my-app
 npm start
 ```
 
-> _NOTE:_ all npm commands can be replaced with yarn
+##### Use with Typescript
+
+It is recommended to use Typescript with our components. You will need to add a few more modules for this to work"
+
+```
+npm i @types/react @types/react-dom @types/classnames @types/node typescript
+npm start
+```
 
 #### Step 2: Install Components
 

--- a/scripts/release/cp-pkgs.js
+++ b/scripts/release/cp-pkgs.js
@@ -80,6 +80,18 @@ function cpAsset(asset) {
     .then(() => console.log(`cp ${asset} -> ${destDir}`));
 }
 
+function addTsIgnore(filePath) {
+  const data = fs.readFileSync(filePath).toString().split('\n');
+  const lineNumber = data.findIndex((lineText) => lineText.includes('/dist/'));
+  if (lineNumber <= -1) return;
+
+  data.splice(lineNumber, 0, '// @ts-ignore');
+  const text = data.join('\n');
+  fs.writeFile(filePath, text, function(err) {
+    if (err) return console.log(err);
+  });
+}
+
 // takes assetPath, computes the destination file directory path
 // and copies file into destination directory
 function cpTypes(typeAsset) {
@@ -88,6 +100,7 @@ function cpTypes(typeAsset) {
   destDir = destDir.split('/');
   destDir.splice(2, 0, 'dist');
   destDir = `${destDir.join('/')}/${base}`;
+  addTsIgnore(typeAsset);
   return cpFile(typeAsset, destDir)
     .then(() => console.log(`cp ${typeAsset} -> ${destDir}`));
 }

--- a/scripts/release/cp-pkgs.js
+++ b/scripts/release/cp-pkgs.js
@@ -80,6 +80,10 @@ function cpAsset(asset) {
     .then(() => console.log(`cp ${asset} -> ${destDir}`));
 }
 
+// this takes a file path to an index.d.ts file and adds an //@ts-ignore comment
+// above the MDC Web imports (any line that includes `/dist/`). We need to ignore
+// these lines since MDC Web does not have typing files
+// TODO: https://github.com/material-components/material-components-web-react/issues/574
 function addTsIgnore(filePath) {
   const data = fs.readFileSync(filePath).toString().split('\n');
   const lineNumber = data.findIndex((lineText) => lineText.includes('/dist/'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "gts/tsconfig-google.json",
   "compilerOptions": {
     "outDir": "./types/",
-    "declaration": true,
     "sourceMap": true,
     "strictNullChecks": true,
     "module": "commonjs",
@@ -17,10 +16,5 @@
   "exclude": [
     "node_modules",
     "build"
-  ],
-  "baseUrl": ".",
-  "paths": {
-    "@material/react-ripple": ["packages/ripple/"],
-    "@material/react-material-icon": ["packages/material-icon/"],
-  }
+  ]
 }


### PR DESCRIPTION
The change to ts-loader increased the amount of memory the webpack config needed. Changing the webpack config to use the multiple entries pattern allows webpack to perform a lot faster.

BREAKING CHANGE: Remove `<package-name>.es.js` files. The alternate is now to use the `index.tsx` files.