### PR TITLE
fix(ripple): Adds HTMLElement shim to fix regression for SSR projects

### DIFF
--- a/packages/ripple/index.tsx
+++ b/packages/ripple/index.tsx
@@ -26,7 +26,7 @@ import {Subtract} from 'utility-types'; // eslint-disable-line no-unused-vars
 // @ts-ignore no mdc .d.ts file
 import {MDCRippleFoundation, MDCRippleAdapter, util} from '@material/ripple/dist/mdc.ripple';
 
-const HTMLElementShim: any = typeof HTMLElement === 'undefined' ? () => {} : HTMLElement;
+const HTMLElementShim: any = typeof HTMLElement === 'undefined' ? {} : HTMLElement;
 const MATCHES = util.getMatchesProperty(HTMLElementShim.prototype);
 
 export interface RippledComponentProps<T> {

--- a/packages/ripple/index.tsx
+++ b/packages/ripple/index.tsx
@@ -26,7 +26,8 @@ import {Subtract} from 'utility-types'; // eslint-disable-line no-unused-vars
 // @ts-ignore no mdc .d.ts file
 import {MDCRippleFoundation, MDCRippleAdapter, util} from '@material/ripple/dist/mdc.ripple';
 
-const MATCHES = util.getMatchesProperty(HTMLElement.prototype);
+const HTMLElementShim: any = typeof HTMLElement === 'undefined' ? () => {} : HTMLElement;
+const MATCHES = util.getMatchesProperty(HTMLElementShim.prototype);
 
 export interface RippledComponentProps<T> {
   unbounded?: boolean;


### PR DESCRIPTION
This PR fixes #581.

I did not write any tests, as writing tests for SSR use cases is under consideration at #588.

The compiled result of the changed code is as follows, which should fix the regression seen in SSR projects:
```js
var HTMLElementShim = typeof HTMLElement === 'undefined' ? { } : HTMLElement;
var MATCHES = mdc_ripple_1.util.getMatchesProperty(HTMLElementShim.prototype);
```

I’m relatively new to writing TypeScript, so please let me know if `any` as a type should be changed.

Warm regards,
Anthony