### PR TITLE
fix(ripple): add missing dependency to package.json

### DIFF
--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@material/ripple": "^0.41.0",
     "classnames": "^2.2.5",
-    "react": "^16.4.2"
+    "react": "^16.4.2",
+    "utility-types": "^3.2.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
utility-types was not listed in the ripple/package.json file, which caused an issue when using a component with ripple.

Found when fixing https://github.com/material-components/material-components-web-react/issues/610