### PR TITLE
[Incomplete, preview] material dialog

### DIFF
--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -1,0 +1,64 @@
+# React Button
+
+A React version of an [MDC Button](https://github.com/material-components/material-components-web/tree/master/packages/mdc-button).
+
+## Installation
+
+```
+npm install @material/react-button
+```
+
+## Usage
+
+### Styles
+
+with Sass:
+```js
+import '@material/react-button/index.scss';
+```
+
+with CSS:
+```js
+import '@material/react-button/dist/button.css';
+```
+
+### Javascript Instantiation
+```js
+import React from 'react';
+import Button from '@material/react-button';
+
+class MyApp extends React.Component {
+  render() {
+    return (
+      <Button>
+        Click Me!
+      </Button>
+    );
+  }
+}
+```
+
+## Props
+
+Prop Name | Type | Description
+--- | --- | ---
+className | String | Classes to be applied to the root element.
+raised | Boolean | Enables raised variant.
+unelevated | Boolean | Enables unelevated variant.
+outlined | Boolean | Enables outlined variant.
+dense | Boolean | Enables dense variant.
+icon | Element | Icon to render within root element.
+children | String | Text to be displayed within root element.
+disabled | Boolean | Disables button if true.
+href | String | Sets a hyperlink & uses anchor tag instead of a button.
+
+## Sass Mixins
+
+Sass mixins may be available to customize various aspects of the Components. Please refer to the
+MDC Web repository for more information on what mixins are available, and how to use them.
+
+[Advanced Sass Mixins](https://github.com/material-components/material-components-web/blob/master/packages/mdc-button/README.md#sass-mixins)
+
+## Usage with Icons
+
+Please see our [Best Practices doc](../../docs/best-practices.md#importing-font-icons) when importing or using icon fonts.

--- a/packages/dialog/index.scss
+++ b/packages/dialog/index.scss
@@ -1,0 +1,23 @@
+// The MIT License
+//
+// Copyright (c) 2018 Google, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@import "@material/button/mdc-button";

--- a/packages/dialog/index.tsx
+++ b/packages/dialog/index.tsx
@@ -21,8 +21,8 @@
 // THE SOFTWARE.
 
 import * as React from 'react';
-import createFocusTrap from 'focus-trap';
-import * as classnames from 'classnames';
+import createFocusTrap = require('focus-trap');
+import classnames from 'classnames';
 import { MDCDialogFoundation, MDCDialogAdapter } from '@material/dialog';
 import { IMDCDialogAdapter } from './types';
 
@@ -31,7 +31,10 @@ type Props = {
   children: React.ReactChild,
   title?: string | null,
   actions?: React.ReactChild,
-  onRequestClose?: () => void,
+  onClose?: () => void,
+  onBeforeClose?: () => void,
+  onOpen?: () => void,
+  onBeforeOpen?: () => void,
 };
 
 type State = {
@@ -67,15 +70,14 @@ export class Dialog extends React.Component<Props, State> {
           }),
       });
   }
-  onDialogClosed = () => {
-      this.props.onRequestClose && this.props.onRequestClose();
-  }
   componentDidMount() {
       this.dialog = new MDCDialogFoundation(this.adapter as unknown as MDCDialogAdapter);
       this.dialog.init();
       this.dialog.open();
       const keydownListener: EventListener = (e: Event) => this.dialog.handleDocumentKeydown(e);
       const resizeListener: EventListener = (e: Event) => this.dialog.layout(e);
+      document.addEventListener('keydown', keydownListener);
+      window.addEventListener('resize', resizeListener);
       this.setState({
           keydownListener,
           resizeListener,
@@ -124,20 +126,32 @@ export class Dialog extends React.Component<Props, State> {
             // TODO
           },
           notifyOpening() {
-            // TODO
+            const { onBeforeOpen } = this.props;
+            if (onBeforeOpen) {
+              onBeforeOpen();
+            }
           },
           notifyOpened() {
-            // TODO
+            const { onOpen } = this.props;
+            if (onOpen) {
+              onOpen();
+            }
           },
           notifyClosing() {
-            // TODO
+            const { onBeforeClose } = this.props;
+            if (onBeforeClose) {
+              onBeforeClose();
+            }
           },
           getActionFromEvent() {
             // TODO
             return 'unknown';
           },
           notifyClosed: () => {
-              this.onDialogClosed();
+            const { onClose } = this.props;
+            if (onClose) {
+              onClose();
+            }
           },
           addBodyClass: (className: string) => {
               document.body && document.body.classList.add(className);

--- a/packages/dialog/index.tsx
+++ b/packages/dialog/index.tsx
@@ -1,0 +1,181 @@
+// The MIT License
+//
+// Copyright (c) 2018 Google, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import * as React from 'react';
+import createFocusTrap from 'focus-trap';
+import * as classnames from 'classnames';
+import { MDCDialogFoundation, MDCDialogAdapter } from '@material/dialog';
+import { IMDCDialogAdapter } from './types';
+
+type Props = {
+  className?: string,
+  children: React.ReactChild,
+  title?: string | null,
+  actions?: React.ReactChild,
+  onRequestClose?: () => void,
+};
+
+type State = {
+  bodyClassList: Set<string>,
+  classList: Set<string>,
+  focusTrap: any,
+  ref: HTMLDivElement | null,
+  resizeListener?: (e: Event) => void,
+  keydownListener?: (e: Event) => void,
+}
+
+
+export class Dialog extends React.Component<Props, State> {
+  dialog: any
+  focusTrapFactory_: any
+  constructor(props: Props) {
+      super(props);
+      this.focusTrapFactory_ = createFocusTrap;
+      this.state = {
+          classList: new Set(),
+          bodyClassList: new Set(),
+          ref: null,
+          focusTrap: null,
+      };
+  }
+  dialogRef = (ref: HTMLDivElement) => {
+      this.setState({
+          ref,
+          focusTrap: this.focusTrapFactory_(ref, {
+              initialFocus: null,
+              escapeDeactivates: false,
+              clickOutsideDeactivates: true,
+          }),
+      });
+  }
+  onDialogClosed = () => {
+      this.props.onRequestClose && this.props.onRequestClose();
+  }
+  componentDidMount() {
+      this.dialog = new MDCDialogFoundation(this.adapter as unknown as MDCDialogAdapter);
+      this.dialog.init();
+      this.dialog.open();
+      const keydownListener: EventListener = (e: Event) => this.dialog.handleDocumentKeydown(e);
+      const resizeListener: EventListener = (e: Event) => this.dialog.layout(e);
+      this.setState({
+          keydownListener,
+          resizeListener,
+      });
+  }
+  componentWillUnmount() {
+      const { keydownListener, resizeListener } = this.state;
+      if (keydownListener)
+          document.removeEventListener('keydown', keydownListener);
+      if (resizeListener)
+          window.removeEventListener('resize', resizeListener);
+      this.dialog.destroy();
+  }
+  handleDialogClick = (e: React.SyntheticEvent) => {
+      this.dialog.handleInteraction(e.nativeEvent);
+  }
+  get adapter():IMDCDialogAdapter {
+      return {
+          addClass: (className: string) => {
+              const classList = new Set(this.state.classList);
+              classList.add(className);
+              this.setState({ classList });
+          },
+          removeClass: (className: string) => {
+              const classList = new Set(this.state.classList);
+              classList.delete(className);
+              this.setState({ classList });
+          },
+          trapFocus: () => this.state.focusTrap.activate(),
+          releaseFocus: () => this.state.focusTrap.deactivate(),
+          eventTargetMatches: (target: HTMLElement, selector: string) => {
+              return target.matches(selector);
+          },
+          isContentScrollable() {
+            // TODO
+            return false;
+          },
+          areButtonsStacked() {
+            // TODO
+            return false;
+          },
+          reverseButtons() {
+            // TODO
+          },
+          clickDefaultButton() {
+            // TODO
+          },
+          notifyOpening() {
+            // TODO
+          },
+          notifyOpened() {
+            // TODO
+          },
+          notifyClosing() {
+            // TODO
+          },
+          getActionFromEvent() {
+            // TODO
+            return 'unknown';
+          },
+          notifyClosed: () => {
+              this.onDialogClosed();
+          },
+          addBodyClass: (className: string) => {
+              document.body && document.body.classList.add(className);
+
+          },
+          removeBodyClass: (className: string) => {
+              document.body && document.body.classList.remove(className);
+          },
+          hasClass: (className: string) => this.classes.split(' ').includes(className),
+      };
+  }
+  get classes() {
+      const { classList } = this.state;
+      return classnames('mdc-dialog', Array.from(classList));
+  }
+  get bodyClasses() {
+      const { bodyClassList } = this.state;
+      return classnames('mdc-dialog__content', Array.from(bodyClassList));
+  }
+  render() {
+      return(<div className={this.classes} onClick={this.handleDialogClick}
+          role="alertdialog"
+          aria-modal="true"
+          ref={this.dialogRef}>
+          <div className="mdc-dialog__container">
+              <div className="mdc-dialog__surface">
+                  {this.props.title ? <h2 className="mdc-dialog__title">{this.props.title}</h2> : null }
+                  <div className={this.bodyClasses}>
+                      {this.props.children}
+                  </div>
+                  <footer className="mdc-dialog__actions">
+                      {this.props.actions}
+                  </footer>
+              </div>
+          </div>
+          <div className="mdc-dialog__scrim" onClick={this.handleDialogClick}></div>
+      </div>);
+  }
+}
+
+export default Dialog;

--- a/packages/dialog/package-lock.json
+++ b/packages/dialog/package-lock.json
@@ -1,0 +1,113 @@
+{
+  "name": "@material/react-button",
+  "version": "0.8.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@material/animation": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-0.41.0.tgz",
+      "integrity": "sha512-yYAwJbX3Q2AFd4dr6IYOsWLQy2HN8zWOFVl9AbUXunjzTfJCa/ecfXCriaT6qkmoNoHeTdJHRrsQJZC5GsPvzA=="
+    },
+    "@material/base": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-0.41.0.tgz",
+      "integrity": "sha512-tEyzwBRu3d1H120SfKsDVYZHcqT5lKohh/7cWKR93aAaPDkSvjpKJIjyu2yuSkjpDduVZGzVocYbOvhUKhhzXQ=="
+    },
+    "@material/dialog": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-0.43.0.tgz",
+      "integrity": "sha512-1WDYfzs7393Zj2BZyyix1NScUMHC+Je5gjXDTjNgmTJ54fC7izkbTeKtllczehnIOqRLPzwiWEtu4JWd+1SWgQ==",
+      "requires": {
+        "@material/animation": "^0.41.0",
+        "@material/base": "^0.41.0",
+        "@material/dom": "^0.41.0",
+        "@material/elevation": "^0.43.0",
+        "@material/ripple": "^0.43.0",
+        "@material/rtl": "^0.42.0",
+        "@material/shape": "^0.43.0",
+        "@material/theme": "^0.43.0",
+        "@material/typography": "^0.43.0",
+        "focus-trap": "^4.0.2"
+      }
+    },
+    "@material/dom": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-0.41.0.tgz",
+      "integrity": "sha512-wOJrMwjPddYXpQFZAIaCLWI3TO/6KU1lxESTBzunni8A4FHQVWhokml5Xt85GqZwmPFeIF2s+D0wfbWyrGBuKQ=="
+    },
+    "@material/elevation": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-0.43.0.tgz",
+      "integrity": "sha512-/OM+7HVS26hCa+AU0dfD/cdEkj2ssYNYIWwmqUVVJUIhB4v/xRsfnCf0Z1KXGtXU+V3AhHp8T9q5LHDzrkOvnA==",
+      "requires": {
+        "@material/animation": "^0.41.0",
+        "@material/theme": "^0.43.0"
+      }
+    },
+    "@material/ripple": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-0.43.0.tgz",
+      "integrity": "sha512-5X5xJtE1tM5QYrsvIe5coZNk7nt++vi40CDBVxS2abO+83ky91I5mH/djcm0vcSFmkHM/QOymEQBR3XDjA3XXQ==",
+      "requires": {
+        "@material/animation": "^0.41.0",
+        "@material/base": "^0.41.0",
+        "@material/theme": "^0.43.0"
+      }
+    },
+    "@material/rtl": {
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-0.42.0.tgz",
+      "integrity": "sha512-VrnrKJzhmspsN8WXHuxxBZ69yM5IwhCUqWr1t1eNfw3ZEvEj7i1g3P31HGowKThIN1dc1Wh4LE14rCISWCtv5w=="
+    },
+    "@material/shape": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-0.43.0.tgz",
+      "integrity": "sha512-KGnoQV4G2OQbMe5Lr5Xbk8XNlO93Qi/juxXtd2wrAfiaPmktD8ug0CwdVDOPBOmj9a0gX3Ofi9XWcoU+tLEVjg=="
+    },
+    "@material/theme": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-0.43.0.tgz",
+      "integrity": "sha512-/zndZL6EihI18v2mYd4O8xvOBAAXmLeHyHVK28LozSAaJ9okQgD25wq5Ktk95oMTmPIC+rH66KcK6371ivNk8g=="
+    },
+    "@material/typography": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-0.43.0.tgz",
+      "integrity": "sha512-WSg8vDoC2rnmOWbhNdDmSoT1jV0QQSw7CFps1DFbnIe57UaUxgWuGdhc+9XlEPctXUFto4FU4DfnRcdW4ydAig=="
+    },
+    "@types/material__base": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@types/material__base/-/material__base-0.35.0.tgz",
+      "integrity": "sha512-B1FUXg67WgvGPn84NIqF/znECgchpISyDzyVifGk1CJ4grNLOzMWaZljWawscBh5RnRP3BujDUR29QG7zRWelw==",
+      "dev": true
+    },
+    "@types/material__dialog": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@types/material__dialog/-/material__dialog-0.35.0.tgz",
+      "integrity": "sha512-Oi1JWGhT0DolQVQ3npzpVagvMZ+jCVj3jR4pn+3w0XL9qu4Cp/fnkRs2gDDbrFd3YBULDYP3Q4nsoerJM2m5AA==",
+      "dev": true,
+      "requires": {
+        "@types/material__base": "*"
+      }
+    },
+    "focus-trap": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
+      "integrity": "sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==",
+      "requires": {
+        "tabbable": "^3.1.2",
+        "xtend": "^4.0.1"
+      }
+    },
+    "tabbable": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
+      "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    }
+  }
+}

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@material/react-button",
+  "version": "0.8.0",
+  "description": "Material Components React Button",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "keywords": [
+    "mdc web react",
+    "material components react",
+    "material design",
+    "material button",
+    "materialbutton"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/material-components/material-components-web-react.git"
+  },
+  "dependencies": {
+    "@material/dialog": "^0.43.0",
+    "classnames": "^2.2.5",
+    "focus-trap": "^4.0.2",
+    "react": "^16.4.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/material__dialog": "^0.35.0"
+  }
+}

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@material/react-button",
-  "version": "0.8.0",
+  "name": "@shortcm/react-dialog",
+  "version": "0.8.92",
   "description": "Material Components React Button",
   "license": "MIT",
   "main": "dist/index.js",
@@ -24,8 +24,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "devDependencies": {
-    "@types/material__dialog": "^0.35.0"
   }
 }

--- a/packages/dialog/types.tsx
+++ b/packages/dialog/types.tsx
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/* eslint no-unused-vars: [2, {"args": "none"}] */
+
+/**
+ * Adapter for MDC Dialog. Provides an interface for managing:
+ * - CSS classes
+ * - DOM
+ * - Event handlers
+ *
+ * Additionally, provides type information for the adapter to the Closure
+ * compiler.
+ *
+ * Implement this adapter for your framework of choice to delegate updates to
+ * the component in your framework of choice. See architecture documentation
+ * for more details.
+ * https://github.com/material-components/material-components-web/blob/master/docs/code/architecture.md
+ *
+ * @record
+ */
+
+ import { MDCFoundation } from '@material/base'
+
+export interface IMDCDialogAdapter {
+    addClass(className: string): void;
+  
+    removeClass(className: string): void;
+  
+    hasClass(className: string): void;
+  
+    addBodyClass(className: string): void;
+  
+    removeBodyClass(className: string): void;
+  
+    eventTargetMatches(target: EventTarget, selector: string): void;
+  
+    trapFocus(): void;
+    releaseFocus(): void;
+  
+    isContentScrollable(): boolean;
+  
+    areButtonsStacked(): boolean
+  
+    getActionFromEvent(event: Event): string
+  
+    clickDefaultButton(): void
+    reverseButtons(): void
+  
+    notifyOpening(): void
+    notifyOpened(): void
+  
+    notifyClosing(action: string): void
+    notifyClosed(action: string): void
+  }
+
+export interface IMDCDialogFoundation extends MDCFoundation<IMDCDialogAdapter> {
+    defaultAdapter: IMDCDialogAdapter
+
+    constructor(adapter: IMDCDialogAdapter): void;
+  
+    init(): void;
+  
+    destroy(): void;
+  
+    open(): void
+  
+    close(action: string) : void;
+  
+    isOpen(): boolean;
+  
+    getEscapeKeyAction(): string;
+  
+    setEscapeKeyAction(action: string): void;
+  
+    getScrimClickAction(): string;
+  
+    setScrimClickAction(action: string) : void
+  
+    getAutoStackButtons() : boolean;
+
+    setAutoStackButtons(autoStack: boolean): void;
+  
+    layout(): void
+  
+    handleInteraction(evt: Event): void
+  
+    handleDocumentKeydown(evt: KeyboardEvent): void;
+}
+  

--- a/scripts/package-json-reader.js
+++ b/scripts/package-json-reader.js
@@ -10,6 +10,9 @@ const readMaterialPackages = () => {
   ];
 
   for (let dep in packageJson.devDependencies) {
+    if (dep.startsWith('@shortcm/')) {
+      dependencies.push(dep);
+    }
     if (dep.startsWith('@material/')) {
       dependencies.push(dep);
     }


### PR DESCRIPTION
Hi

For my project, I need material-dialog, which was implemented internally. Now I want to backport it to react components.

Can you please check if it is the correct direction? If yes, I'll add missing adapter methods, update docs and tests

Currently it is used by my project with the name @shortcm/react-dialog and the module is public