### PR TITLE
docs(dialog): Example variable choice already existed, and 'c' no longer did.

### DIFF
--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -194,7 +194,7 @@ class Confirmation extends Component
                         value={choice}
                         id={cleanChoice}
                         checked={this.isChecked(i)}
-                        onChange={() => {} }
+                        onChange={() => {}}
                       />
                     </Radio>
                   </span>

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -183,7 +183,7 @@ class Confirmation extends Component
             singleSelection 
             handleSelect={ (selectedIndex) => this.setState({selectedIndex})}
           >{choices.map((choice, i) => {
-              let choice = choice.replace(/\s/g, '-');
+              let cleanChoice = choice.replace(/\s/g, '-');
               return (
                 <ListItem key={i}>
                   <!-- Note: <ListItemGraphic/> will not work here -->
@@ -192,13 +192,13 @@ class Confirmation extends Component
                       <NativeRadioControl
                         name='ringtone'
                         value={choice}
-                        id={c}
+                        id={cleanChoice}
                         checked={this.isChecked(i)}
                         onChange={() => {} }
                       />
                     </Radio>
                   </span>
-                  <label htmlFor={c}>
+                  <label htmlFor={cleanChoice}>
                     <ListItemText primaryText={choice}/>
                 </label>
                 </ListItem>


### PR DESCRIPTION
Fix Dialog documentation. Example would not work properly because variable c had been renamed, but not changed in all places.Additionally, it was renamed to a variable that already existed.

> Note: I did not open an issue for this. I can if you prefer. 

---

I signed it