### PR TITLE
Fix screenshot tests for external contributors and pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ matrix:
         - docker pull mdcreact/screenshots
         - docker image ls
       script:
-        - docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY="${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}" -e CURRENT_SLUG="${CURRENT_SLUG}" mdcreact/screenshots /bin/sh -c "git remote rm origin; git remote add origin https://github.com/${CURRENT_SLUG}; git checkout .; git fetch; git checkout \"${CURRENT_BRANCH}\"; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 35s; npm run test:image-diff"
+        - docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY="${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}" -e CURRENT_SLUG="${CURRENT_SLUG}" mdcreact/screenshots /bin/sh -c "git remote rm origin; git remote add origin https://github.com/${CURRENT_SLUG}; git checkout .; git fetch; git checkout \"${CURRENT_BRANCH}\"; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 40s; npm run test:image-diff"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ git:
 dist: trusty
 sudo: required
 
-branches:
-  only:
-    - master
-    - rc0.10.0
-
 matrix:
   include:
     - node_js: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ matrix:
       env:
         - TEST_SUITE=screenshots
         - CURRENT_BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+        - CURRENT_SLUG=$(if [ "x$TRAVIS_PULL_REQUEST_SLUG" == "x" ]; then echo $TRAVIS_REPO_SLUG; else echo $TRAVIS_PULL_REQUEST_SLUG; fi) 
       before_install:
         - docker pull mdcreact/screenshots
         - docker image ls
       script:
-        - docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY="${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}" -e TRAVIS_REPO_SLUG="${TRAVIS_REPO_SLUG}" mdcreact/screenshots /bin/sh -c "git remote rm origin; git remote add origin https://github.com/${TRAVIS_REPO_SLUG}; git checkout .; git fetch; git checkout \"${CURRENT_BRANCH}\"; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 35s; npm run test:image-diff"
+        - docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY="${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}" -e CURRENT_SLUG="${CURRENT_SLUG}" mdcreact/screenshots /bin/sh -c "git remote rm origin; git remote add origin https://github.com/${CURRENT_SLUG}; git checkout .; git fetch; git checkout \"${CURRENT_BRANCH}\"; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 35s; npm run test:image-diff"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ matrix:
         - docker pull mdcreact/screenshots
         - docker image ls
       script:
-        - docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY="${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}" mdcreact/screenshots /bin/sh -c "git checkout .; git fetch; git checkout \"${CURRENT_BRANCH}\"; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 35s; npm run test:image-diff"
+        - docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY="${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}" -e TRAVIS_REPO_SLUG="${TRAVIS_REPO_SLUG}" mdcreact/screenshots /bin/sh -c "git remote rm origin; git remote add origin https://github.com/${TRAVIS_REPO_SLUG}; git checkout .; git fetch; git checkout \"${CURRENT_BRANCH}\"; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 35s; npm run test:image-diff"

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,27 +70,6 @@ conventional-changelog -p angular -i CHANGELOG.md -s -r 0
 
 The `CHANGELOG.md` will also be updated with the new version's changes. You will need to edit the header of the file at the very least. If you need to **edit** any other parts of the `CHANGELOG.md`, now is the time.
 
-#### Update .travis.yml config
-
-The `.travis.yml` file will need to be updated before merging into master. Remove the RC branch from the `branches` property in the config.
-
-Original:
-
-```
-branches:
-  only:
-    - master
-    - rc0.7.x # remove this
-```
-
-Updated:
-
-```
-branches:
-  only:
-    - master
-```
-
 #### Commit Changes
 
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -126,12 +126,3 @@ If it hasn't already been done, you will need to create a new RC branch. If the 
     * `Include administrators`
     * `Restrict who can push to matching branches`
     * Should look like this:  ![protectionrule](https://user-images.githubusercontent.com/579873/48811016-b4814400-ece0-11e8-9a7e-1a9838ecf764.png)
-
-* [ ] Update the `.travis.yml` config
-  * Add the RC branch to the `branches` property in the config.
-  * ```
-    branches:
-      only:
-        - master
-        - rc0.8.0 # add this
-  ```

--- a/docs/screenshot-tests.md
+++ b/docs/screenshot-tests.md
@@ -94,14 +94,6 @@ Then commit and push this change to your PR!
 
 > _NOTE_: If you have two-factor authentication turned on for your GitHub account, you'll need to use a [Personal Access Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) to push.
 
-## Running tests without docker
-
-If you have google-chrome-unstable package available, you can just run
-
-```
-npm run test:local-screenshots
-```
-
 ## Troubleshooting
 
 ### Building New Docker Image

--- a/docs/screenshot-tests.md
+++ b/docs/screenshot-tests.md
@@ -94,6 +94,14 @@ Then commit and push this change to your PR!
 
 > _NOTE_: If you have two-factor authentication turned on for your GitHub account, you'll need to use a [Personal Access Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) to push.
 
+## Running tests without docker
+
+If you have google-chrome-unstable package available, you can just run
+
+```
+npm run test:local-screenshots
+```
+
 ## Troubleshooting
 
 ### Building New Docker Image

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test:unit-ci": "karma start karma.ci.js --single-run",
     "test:image-diff": "MDC_COMMIT_HASH=$(git rev-parse --short HEAD) MDC_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) mocha --require ts-node/register --require babel-core/register --ui tdd --timeout 30000 test/screenshot/diff-suite.tsx",
     "test:screenshots": "docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY=\"${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}\" mdcreact/screenshots /bin/sh -c 'git checkout .; git checkout master; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 35s; npm run test:image-diff'",
-    "test:local-screenshots": "./test/screenshot/start.sh && sleep 35s && npm run test:image-diff",
     "upload:screenshots": "node ./test/screenshot/upload-screenshots.js"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/enzyme": "^3.1.15",
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/google-cloud__storage": "^1.7.2",
+    "@types/mkdirp": "^0.5.2",
     "@types/mocha": "^5.2.5",
     "@types/prop-types": "^15.5.6",
     "@types/puppeteer": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:unit-ci": "karma start karma.ci.js --single-run",
     "test:image-diff": "MDC_COMMIT_HASH=$(git rev-parse --short HEAD) MDC_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) mocha --require ts-node/register --require babel-core/register --ui tdd --timeout 30000 test/screenshot/diff-suite.tsx",
     "test:screenshots": "docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY=\"${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}\" mdcreact/screenshots /bin/sh -c 'git checkout .; git checkout master; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 35s; npm run test:image-diff'",
+    "test:local-screenshots": "./test/screenshot/start.sh && sleep 35s && npm run test:image-diff",
     "upload:screenshots": "node ./test/screenshot/upload-screenshots.js"
   },
   "config": {
@@ -100,6 +101,7 @@
     "@types/uuid": "^3.4.4",
     "@types/webpack-env": "^1.13.6",
     "autoprefixer": "^8.5.1",
+    "axios": "^0.18.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.4",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "react-dom": "^16.4.2",
     "react-router-dom": "^4.3.1",
     "remap-istanbul": "^0.12.0",
-    "resemblejs": "^2.10.3",
+    "resemblejs": "^3.0.1",
     "sass-loader": "^6.0.7",
     "testdouble": "^3.6.0",
     "ts-loader": "^3.5.0",

--- a/test/screenshot/screenshot.tsx
+++ b/test/screenshot/screenshot.tsx
@@ -28,11 +28,11 @@ const defaultMetadata = {
 let storage: Storage|null = null;
 let bucket: Storage.Bucket|null = null;
 if (serviceAccountKey) {
-    storage = new Storage({
-      credentials: JSON.parse(serviceAccountKey),
-    });
+  storage = new Storage({
+    credentials: JSON.parse(serviceAccountKey),
+  });
 
-    bucket = storage.bucket(bucketName);
+  bucket = storage.bucket(bucketName);
 }
 
 export default class Screenshot {
@@ -98,14 +98,14 @@ export default class Screenshot {
         return;
       }
       // Save the snapshot and the diff
-      if (storage)  {
+      if (storage) {
         await Promise.all([
           this.saveImage_(snapshotPath, snapshot, metadata),
           this.saveImage_(diffPath, diff, metadata),
         ]);
       }
       if (Number(data.misMatchPercentage) > 0) {
-        mkdirp.sync(path.dirname('no_match/' + diffPath))
+        mkdirp.sync(path.dirname('no_match/' + diffPath));
         await writeFilePromise('no_match/' + diffPath, diff);
       }
       return assert.equal(Number(data.misMatchPercentage), 0);
@@ -161,7 +161,7 @@ export default class Screenshot {
       responseType: 'arraybuffer',
     });
     console.log(gcsFilePath);
-    return response.data
+    return response.data;
   }
   /**
    * Saves the golden hash
@@ -184,8 +184,9 @@ export default class Screenshot {
    */
   async saveImage_(imagePath: string, imageBuffer: Buffer, customMetadata: Storage.CustomFileMetadata = {}) {
     const metadata: Storage.CustomFileMetadata = Object.assign({}, defaultMetadata, customMetadata);
-    if (!bucket)
+    if (!bucket) {
       throw new Error('GCS is not configured');
+    }
     const file = bucket.file(imagePath);
     // Check if file exists and exit if it does
     const [exists] = await file.exists();

--- a/test/screenshot/screenshot.tsx
+++ b/test/screenshot/screenshot.tsx
@@ -160,7 +160,6 @@ export default class Screenshot {
       url,
       responseType: 'arraybuffer',
     });
-    console.log(gcsFilePath);
     return response.data;
   }
   /**

--- a/test/screenshot/screenshot.tsx
+++ b/test/screenshot/screenshot.tsx
@@ -10,6 +10,9 @@ import {assert} from 'chai';
 import * as Storage from '@google-cloud/storage';
 import comparisonOptions from './screenshot-comparison-options';
 import axios from 'axios';
+import * as path from 'path';
+import * as mkdirp from 'mkdirp';
+
 const readFilePromise = promisify(readFile);
 const writeFilePromise = promisify(writeFile);
 const serviceAccountKey: string = process.env.MDC_GCLOUD_SERVICE_ACCOUNT_KEY || '';
@@ -100,6 +103,10 @@ export default class Screenshot {
           this.saveImage_(snapshotPath, snapshot, metadata),
           this.saveImage_(diffPath, diff, metadata),
         ]);
+      }
+      if (Number(data.misMatchPercentage) > 0) {
+        mkdirp.sync(path.dirname('no_match/' + diffPath))
+        await writeFilePromise('no_match/' + diffPath, diff);
       }
       return assert.equal(Number(data.misMatchPercentage), 0);
     });

--- a/test/screenshot/screenshot.tsx
+++ b/test/screenshot/screenshot.tsx
@@ -25,6 +25,8 @@ const defaultMetadata = {
   branch: branchName,
 };
 
+const NO_MATCH_DIRECTORY = 'no_match';
+
 let storage: Storage|null = null;
 let bucket: Storage.Bucket|null = null;
 if (serviceAccountKey) {
@@ -105,8 +107,8 @@ export default class Screenshot {
         ]);
       }
       if (Number(data.misMatchPercentage) > 0) {
-        mkdirp.sync(path.dirname('no_match/' + diffPath));
-        await writeFilePromise('no_match/' + diffPath, diff);
+        mkdirp.sync(path.dirname(`${NO_MATCH_DIRECTORY}/${diffPath}`));
+        await writeFilePromise(`${NO_MATCH_DIRECTORY}/${diffPath}`, diff);
       }
       return assert.equal(Number(data.misMatchPercentage), 0);
     });


### PR DESCRIPTION
What was changed:

1. Golden screenshots are downloaded with their public URL, not with GCS API. The comparison will become available for everyone
2. If there are no GSC token available, tests still compare screenshots with Golden but do not upload anything
3. travis.yml tests will run for every branch of every repository, not only for master of main repository

This means if no UI changes, screenshot tests will pass. Goldens will still need to be uploaded manually