### PR TITLE
Do not import constants from @material/textfield internals

### DIFF
--- a/packages/text-field/Input.tsx
+++ b/packages/text-field/Input.tsx
@@ -23,8 +23,10 @@ import * as React from 'react';
 import * as classnames from 'classnames';
 // @ts-ignore no .d.ts file
 import {MDCTextFieldFoundation} from '@material/textfield/dist/mdc.textfield';
-// @ts-ignore no .d.ts file
-import {VALIDATION_ATTR_WHITELIST} from '@material/textfield/constants';
+
+const VALIDATION_ATTR_WHITELIST = [
+  'pattern', 'min', 'max', 'required', 'step', 'minlength', 'maxlength'
+]
 
 export interface InputProps<T> {
   className: string;

--- a/packages/text-field/Input.tsx
+++ b/packages/text-field/Input.tsx
@@ -24,10 +24,6 @@ import * as classnames from 'classnames';
 // @ts-ignore no .d.ts file
 import {MDCTextFieldFoundation} from '@material/textfield/dist/mdc.textfield';
 
-const VALIDATION_ATTR_WHITELIST = [
-  'pattern', 'min', 'max', 'required', 'step', 'minlength', 'maxlength'
-]
-
 export interface InputProps<T> {
   className: string;
   inputType: 'input' | 'textarea';
@@ -59,6 +55,11 @@ declare type ValidationAttrWhiteList =
   'pattern' | 'min' | 'max' | 'required' | 'step' | 'minlength' | 'maxlength';
 declare type ValidationAttrWhiteListReact =
   Exclude<ValidationAttrWhiteList, 'minlength' | 'maxlength'> | 'minLength' | 'maxLength';
+
+const VALIDATION_ATTR_WHITELIST: ValidationAttrWhiteList[] = [
+  'pattern', 'min', 'max', 'required', 'step', 'minlength', 'maxlength',
+];
+
 
 export default class Input<T extends {}> extends React.Component<
   Props<T>, InputState


### PR DESCRIPTION
This line imports constants module not from @material/textfield/dist, but from original source code
```
import {VALIDATION_ATTR_WHITELIST} from '@material/textfield/constants';
```

`@material/textfield/constants` is written in Babel language (I don't know how to call it) and contains babel export construction. If someone tries to use textfield from node.js test, it will fail

It is regression as it worked for version 0.7.0