### PR TITLE
docs(list): fix ListDivider example

### DIFF
--- a/packages/list/README.md
+++ b/packages/list/README.md
@@ -134,7 +134,7 @@ class MyApp extends Component {
           </ListItem>
           ...
         </List>
-        <ListDivider />
+        <ListDivider tag="div" />
         <ListGroupSubheader tag='h2'>Recent Files</ListGroupSubheader>
         <List>
           <ListItem>


### PR DESCRIPTION
ListDivider should have `div` tag instead of default `li` when used outside of `<List>`