### PR TITLE
fix(list): renders a list with children which is not DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@material/list": "^0.41.0",
     "@material/menu-surface": "^0.41.0",
     "@material/notched-outline": "^0.41.0",
+    "@material/radio": "^0.41.0",
     "@material/ripple": "^0.41.0",
     "@material/select": "^0.40.1",
     "@material/snackbar": "^0.43.0",

--- a/packages/list/index.tsx
+++ b/packages/list/index.tsx
@@ -67,7 +67,7 @@ function isReactText(element: any): element is React.ReactText {
 }
 
 function isListItem(element: any): element is ListItem {
-  return element.type === ListItem;
+  return element && element.type === ListItem;
 }
 
 export default class List<T extends HTMLElement = HTMLElement> extends React.Component<ListProps<T>, ListState> {

--- a/test/unit/list/index.test.tsx
+++ b/test/unit/list/index.test.tsx
@@ -411,5 +411,5 @@ test('renders a list with children which is not DOM', () => {
     {null}
     {undefined}
   </List>);
-  assert.isNotEmpty(wrapper);
+  assert.isTrue(wrapper.children().length === 1);
 });

--- a/test/unit/list/index.test.tsx
+++ b/test/unit/list/index.test.tsx
@@ -402,3 +402,14 @@ test('renders a list with a nav tag', () => {
   const wrapper = shallow(<List tag='nav'>{children()}</List>);
   assert.equal(wrapper.type(), 'nav');
 });
+
+test('renders a list with children which is not DOM', () => {
+  const wrapper = shallow(<List>
+    {}
+    {false}
+    {'text'}
+    {null}
+    {undefined}
+  </List>);
+  assert.isNotEmpty(wrapper);
+});


### PR DESCRIPTION
Now ```<List />```checks children's type using ```isListItem```.
If parameter is null/undefined, an error occurs.
So I add code that checks element's existence.

p.s. I add one dependency(@material/radio) because there is error "cannot find module" when running test code. If you do not need it, I will revert it.