### PR TITLE
fix(chips): null check for checkmark ref

### DIFF
--- a/packages/chips/ChipSet.tsx
+++ b/packages/chips/ChipSet.tsx
@@ -146,8 +146,8 @@ export default class ChipSet extends React.Component<ChipSetProps, ChipSetState>
     updateChips(chipsArray);
   };
 
-  setCheckmarkWidth = (checkmark: ChipCheckmark) => {
-    if (!!this.checkmarkWidth) {
+  setCheckmarkWidth = (checkmark: ChipCheckmark | null) => {
+    if (!!this.checkmarkWidth || !checkmark) {
       return;
     }
     this.checkmarkWidth = checkmark.width;

--- a/test/unit/chips/ChipSet.test.tsx
+++ b/test/unit/chips/ChipSet.test.tsx
@@ -223,6 +223,12 @@ test('#setCheckmarkWidth does not set checkmark width if checkmark width is alre
   assert.equal(wrapper.instance().checkmarkWidth, 20);
 });
 
+test('#setCheckmarkWidth does not set checkmark width if checkmark is null', () => {
+  const wrapper = shallow<ChipSet>(<ChipSet><Chip id='1' /></ChipSet>);
+  wrapper.instance().setCheckmarkWidth(null);
+  assert.equal(wrapper.instance().checkmarkWidth, 0);
+});
+
 test('#computeBoundingRect returns width and height', () => {
   const wrapper = shallow<ChipSet>(<ChipSet><Chip /></ChipSet>);
   const chipWidth = 20;


### PR DESCRIPTION
fixes chips when filter chips are unmounted. setCheckmarkWidth ref method is called, but `checkmark` is null.