### PR TITLE
fix(button): Support anchor and button HTML attributes (#679)

### DIFF
--- a/packages/button/index.tsx
+++ b/packages/button/index.tsx
@@ -28,16 +28,17 @@ const BUTTON_CLASS_NAME = 'mdc-button__icon';
 
 type ButtonTypes = HTMLAnchorElement | HTMLButtonElement;
 
-export interface ButtonProps<T extends ButtonTypes> extends Ripple.InjectedProps<T>, React.HTMLAttributes<T> {
-  raised?: boolean;
-  unelevated?: boolean;
-  outlined?: boolean;
-  dense?: boolean;
-  disabled?: boolean;
-  className?: string;
-  icon?: React.ReactElement<React.HTMLProps<HTMLOrSVGElement>>;
-  href?: string;
-  trailingIcon?: React.ReactElement<React.HTMLProps<HTMLOrSVGElement>>;
+export interface ButtonProps<T extends ButtonTypes>
+  extends Ripple.InjectedProps<T>, React.AnchorHTMLAttributes<T>, React.ButtonHTMLAttributes<T> {
+    raised?: boolean;
+    unelevated?: boolean;
+    outlined?: boolean;
+    dense?: boolean;
+    disabled?: boolean;
+    className?: string;
+    icon?: React.ReactElement<React.HTMLProps<HTMLOrSVGElement>>;
+    href?: string;
+    trailingIcon?: React.ReactElement<React.HTMLProps<HTMLOrSVGElement>>;
 }
 
 export const Button = <T extends ButtonTypes>(

--- a/test/unit/button/index.test.tsx
+++ b/test/unit/button/index.test.tsx
@@ -66,6 +66,16 @@ test('renders a button with an anchor tag', () => {
   assert.equal(wrapper.type(), 'a');
 });
 
+test('renders a button with a button attribute', () => {
+  const wrapper = shallow(<Button type='submit' />);
+  assert.equal(wrapper.prop('type'), 'submit');
+});
+
+test('renders a button with an anchor attribute', () => {
+  const wrapper = shallow(<Button download />);
+  assert.equal(wrapper.prop('download'), true);
+});
+
 test('default initRipple function', () => {
   const initRipple = coerceForTesting<(surface: HTMLButtonElement) => {}>(td.func());
   mount(<Button initRipple={initRipple} />);


### PR DESCRIPTION
I've chosen to extend `React.AnchorHTMLAttributes<T>` and `React.ButtonHTMLAttributes<T>` since these are the possible element types that can be rendered. However looking through the other components you seem to use `HTMLProps<T>` a lot as well. There doesn't seem to be any clear reason why this is used in some places and not in others.

I'm happy to change this to use `HTMLProps<T>` instead if that is the pattern you want to follow. It would make button consistent with icon-button.