### PR TITLE
fix(infrastructure): fix source mappings under dist directory

### DIFF
--- a/scripts/release/cp-pkgs.js
+++ b/scripts/release/cp-pkgs.js
@@ -59,19 +59,14 @@ function cpAsset(asset) {
 
   let basename = path.basename(asset);
   const extname = path.extname(asset);
-  const isMap = extname === '.map';
   const isJs = extname === '.js';
   const isEs = basename.includes('.es');
   const isCss = basename.includes('.css');
-  if (!isEs && !isCss && (isJs || isMap )) {
-    if (isMap) {
-      basename = 'index.js.map';
+  if (!isEs && !isCss && isJs) {
+    if (basename.includes('.min')) {
+      basename = 'index.min.js';
     } else {
-      if (basename.includes('.min')) {
-        basename = 'index.min.js';
-      } else {
-        basename = 'index.js';
-      }
+      basename = 'index.js';
     }
   }
 


### PR DESCRIPTION
fixes https://github.com/material-components/material-components-web-react/issues/681

Stop renaming `foo-package.js.map` to `index.js.map`. This is linked to the `dist/index.js`.