### PR TITLE
update classnames version to 2.2.6

### DIFF
--- a/packages/chips/package.json
+++ b/packages/chips/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@material/chips": "^0.41.0",
     "@material/react-ripple": "^0.10.0",
-    "classnames": "^2.2.5",
+    "classnames": "^2.2.6",
     "react": "^16.4.2"
   },
   "publishConfig": {


### PR DESCRIPTION
a fix for this error:
https://github.com/JedWatson/classnames/pull/106
was added in classnames v 2.2.6.

update dependency version from 2.2.5 to 2.2.6