### PR TITLE
fix(text-field): input not rendered on SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit": "npm run clean && cross-env NODE_ENV=test karma start karma.local.js --single-run",
     "test:unit-ci": "karma start karma.ci.js --single-run",
     "test:image-diff": "MDC_COMMIT_HASH=$(git rev-parse --short HEAD) MDC_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) mocha --require ts-node/register --require babel-core/register --ui tdd --timeout 60000 test/screenshot/diff-suite.tsx",
-    "test:screenshots": "docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY=\"${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}\" mdcreact/screenshots /bin/sh -c 'git checkout .; git checkout master; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 60s; npm run test:image-diff'",
+    "test:screenshots": "docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY=\"${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}\" mdcreact/screenshots /bin/sh -c 'git checkout .; git checkout master; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 40s; npm run test:image-diff'",
     "upload:screenshots": "node ./test/screenshot/upload-screenshots.js"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit": "npm run clean && cross-env NODE_ENV=test karma start karma.local.js --single-run",
     "test:unit-ci": "karma start karma.ci.js --single-run",
     "test:image-diff": "MDC_COMMIT_HASH=$(git rev-parse --short HEAD) MDC_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) mocha --require ts-node/register --require babel-core/register --ui tdd --timeout 60000 test/screenshot/diff-suite.tsx",
-    "test:screenshots": "docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY=\"${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}\" mdcreact/screenshots /bin/sh -c 'git checkout .; git checkout master; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 40s; npm run test:image-diff'",
+    "test:screenshots": "docker run -it --rm --cap-add=SYS_ADMIN -e MDC_GCLOUD_SERVICE_ACCOUNT_KEY=\"${MDC_GCLOUD_SERVICE_ACCOUNT_KEY}\" mdcreact/screenshots /bin/sh -c 'git checkout .; git checkout master; git pull; npm i; /home/pptruser/material-components-web-react/test/screenshot/start.sh; sleep 60s; npm run test:image-diff'",
     "upload:screenshots": "node ./test/screenshot/upload-screenshots.js"
   },
   "config": {

--- a/packages/text-field/Input.tsx
+++ b/packages/text-field/Input.tsx
@@ -134,7 +134,7 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       handleValueChange && handleValueChange(value, () => {
         // only call #foundation.setValue on programatic changes;
         // not changes by the user. or when we go from no foundation
-        // to having a foundation, since we don't have that guaranteeded
+        // to having a foundation, since we don't have that guaranteed
         // anymore
         if (this.state.wasUserTriggeredChange && prevProps.foundation === foundation) {
           this.setState({wasUserTriggeredChange: false});

--- a/packages/text-field/Input.tsx
+++ b/packages/text-field/Input.tsx
@@ -134,10 +134,8 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
 
     if ((value !== prevProps.value || foundationChanged) && foundation) {
       handleValueChange && handleValueChange(value, () => {
-        // only call #foundation.setValue on programatic changes;
-        // not changes by the user. or when we go from no foundation
-        // to having a foundation, since we don't have that guaranteed
-        // anymore
+        // #foundation.setValue should only be called on programatic changes,
+        // not changes by the user, nor when the foundation changes.
         if (this.state.wasUserTriggeredChange && !foundationChanged) {
           this.setState({wasUserTriggeredChange: false});
         } else {

--- a/packages/text-field/Input.tsx
+++ b/packages/text-field/Input.tsx
@@ -98,10 +98,10 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
     if (setDisabled && disabled) {
       setDisabled(true);
     }
-    if (handleValueChange && value) {
+    if (handleValueChange && value && foundation) {
       handleValueChange(value, () => foundation.setValue(value));
     }
-    if (isValid !== undefined && foundation !== null) {
+    if (isValid !== undefined && foundation) {
       foundation.setUseNativeValidation(false);
       foundation.setValid(isValid);
     }
@@ -121,7 +121,7 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
 
     this.handleValidationAttributeUpdate(prevProps);
 
-    if (disabled !== prevProps.disabled) {
+    if ((disabled !== prevProps.disabled || prevProps.foundation !== foundation) && foundation) {
       setDisabled && setDisabled(disabled!);
       foundation.setDisabled(disabled);
     }
@@ -130,11 +130,13 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       setInputId && setInputId(id!);
     }
 
-    if (value !== prevProps.value) {
+    if ((value !== prevProps.value || prevProps.foundation !== foundation) && foundation) {
       handleValueChange && handleValueChange(value, () => {
         // only call #foundation.setValue on programatic changes;
-        // not changes by the user.
-        if (this.state.wasUserTriggeredChange) {
+        // not changes by the user. or when we go from no foundation
+        // to having a foundation, since we don't have that guaranteeded
+        // anymore
+        if (this.state.wasUserTriggeredChange && prevProps.foundation === foundation) {
           this.setState({wasUserTriggeredChange: false});
         } else {
           foundation.setValue(value);
@@ -142,7 +144,7 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       });
     }
 
-    if (isValid !== prevProps.isValid || foundation !== prevProps.foundation) {
+    if ((isValid !== prevProps.isValid || foundation !== prevProps.foundation) && foundation) {
       if (isValid === undefined) {
         foundation.setUseNativeValidation(true);
       } else {

--- a/packages/text-field/Input.tsx
+++ b/packages/text-field/Input.tsx
@@ -90,6 +90,7 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       setDisabled,
       handleValueChange,
       foundation,
+      isValid,
     } = this.props;
     if (setInputId && id) {
       setInputId(id!);
@@ -99,6 +100,10 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
     }
     if (handleValueChange && value) {
       handleValueChange(value, () => foundation.setValue(value));
+    }
+    if (isValid !== undefined && foundation !== null) {
+      foundation.setUseNativeValidation(false);
+      foundation.setValid(isValid);
     }
   }
 

--- a/packages/text-field/Input.tsx
+++ b/packages/text-field/Input.tsx
@@ -121,7 +121,9 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
 
     this.handleValidationAttributeUpdate(prevProps);
 
-    if ((disabled !== prevProps.disabled || prevProps.foundation !== foundation) && foundation) {
+    const foundationChanged = prevProps.foundation !== foundation;
+
+    if ((disabled !== prevProps.disabled || foundationChanged) && foundation) {
       setDisabled && setDisabled(disabled!);
       foundation.setDisabled(disabled);
     }
@@ -130,13 +132,13 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       setInputId && setInputId(id!);
     }
 
-    if ((value !== prevProps.value || prevProps.foundation !== foundation) && foundation) {
+    if ((value !== prevProps.value || foundationChanged) && foundation) {
       handleValueChange && handleValueChange(value, () => {
         // only call #foundation.setValue on programatic changes;
         // not changes by the user. or when we go from no foundation
         // to having a foundation, since we don't have that guaranteed
         // anymore
-        if (this.state.wasUserTriggeredChange && prevProps.foundation === foundation) {
+        if (this.state.wasUserTriggeredChange && !foundationChanged) {
           this.setState({wasUserTriggeredChange: false});
         } else {
           foundation.setValue(value);
@@ -144,7 +146,7 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       });
     }
 
-    if ((isValid !== prevProps.isValid || foundation !== prevProps.foundation) && foundation) {
+    if ((isValid !== prevProps.isValid || foundationChanged) && foundation) {
       if (isValid === undefined) {
         foundation.setUseNativeValidation(true);
       } else {

--- a/packages/text-field/Input.tsx
+++ b/packages/text-field/Input.tsx
@@ -90,7 +90,6 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       setDisabled,
       handleValueChange,
       foundation,
-      isValid,
     } = this.props;
     if (setInputId && id) {
       setInputId(id!);
@@ -100,10 +99,6 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
     }
     if (handleValueChange && value) {
       handleValueChange(value, () => foundation.setValue(value));
-    }
-    if (isValid !== undefined) {
-      foundation.setUseNativeValidation(false);
-      foundation.setValid(isValid);
     }
   }
 
@@ -142,7 +137,7 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       });
     }
 
-    if (isValid !== prevProps.isValid) {
+    if (isValid !== prevProps.isValid || foundation !== prevProps.foundation) {
       if (isValid === undefined) {
         foundation.setUseNativeValidation(true);
       } else {

--- a/packages/text-field/index.tsx
+++ b/packages/text-field/index.tsx
@@ -329,7 +329,7 @@ class TextField<T extends HTMLElement = HTMLInputElement> extends React.Componen
         key='text-field-container'
       >
         {leadingIcon ? this.renderIcon(leadingIcon, onLeadingIconSelect) : null}
-        {foundation ? this.renderInput() : null}
+        {this.renderInput()}
         {label && !fullWidth ? this.renderLabel() : null}
         {outlined ? this.renderNotchedOutline() : null}
         {!fullWidth && !textarea && !outlined ? this.renderLineRipple() : null}

--- a/test/screenshot/screenshot.tsx
+++ b/test/screenshot/screenshot.tsx
@@ -232,7 +232,7 @@ export default class Screenshot {
     });
     const page = await browser.newPage();
     await page.goto(`http://localhost:8080/#/${this.urlPath_}`, {
-      waitUntil: ['networkidle2'],
+      waitUntil: ['networkidle0'],
       timeout: 600000,
     });
     // await page.waitForSelector('#screenshot-test-app');

--- a/test/screenshot/screenshot.tsx
+++ b/test/screenshot/screenshot.tsx
@@ -232,7 +232,7 @@ export default class Screenshot {
     });
     const page = await browser.newPage();
     await page.goto(`http://localhost:8080/#/${this.urlPath_}`, {
-      waitUntil: ['networkidle0'],
+      waitUntil: ['load'],
       timeout: 600000,
     });
     // await page.waitForSelector('#screenshot-test-app');

--- a/test/unit/text-field/Input.test.tsx
+++ b/test/unit/text-field/Input.test.tsx
@@ -405,3 +405,13 @@ test('#inputElement should return the native input', () => {
   assert.equal(inputElement!.tagName.toLowerCase(), 'input');
   assert.isTrue(inputElement instanceof HTMLInputElement);
 });
+
+test('should call foundation.setValue() when foundation is new', () => {
+  const wrapper = shallow<Input<HTMLInputElement>>(<Input />);
+  const setValue = td.func();
+  const foundation = {setValue, setDisabled: td.func(), setUseNativeValidation: td.func()};
+  const handleValueChange = (_: any, callback: () => void) => callback();
+  const value = 'meow';
+  wrapper.setProps({foundation, value, handleValueChange});
+  td.verify(foundation.setValue(value), {times: 1});
+});

--- a/test/unit/text-field/Input.test.tsx
+++ b/test/unit/text-field/Input.test.tsx
@@ -415,3 +415,28 @@ test('should call foundation.setValue() when foundation is new', () => {
   wrapper.setProps({foundation, value, handleValueChange});
   td.verify(foundation.setValue(value), {times: 1});
 });
+
+test('shouldn\'t call foundation.setValue() when triggered by user', () => {
+  const setValue = td.func();
+  const foundation = {
+    setValue,
+    setDisabled: td.func(),
+    setUseNativeValidation: td.func(),
+    autoCompleteFocus: td.func(),
+  };
+  let value: any;
+  const handleValueChange = (v: any, callback: () => void) => {
+    value = v;
+    callback();
+  };
+  const wrapper = shallow<Input<HTMLInputElement>>(
+    <Input
+      handleValueChange={handleValueChange}
+      foundation={foundation}
+    />
+  );
+  const event = {target: {value: 'meow'}};
+  wrapper.simulate('change', event);
+  wrapper.setProps({value});
+  td.verify(foundation.setValue(), {times: 0});
+});

--- a/test/unit/text-field/Input.test.tsx
+++ b/test/unit/text-field/Input.test.tsx
@@ -137,7 +137,8 @@ test('#componentDidMount should not call any method if disabled and id do not ex
 test('#componentDidMount calls props.handleValueChange when the foundation initializes with a value', () => {
   const handleValueChange = td.func();
   const value = 'test value';
-  const props: any = {handleValueChange, value};
+  const foundation = {};
+  const props: any = {handleValueChange, value, foundation};
   shallow(<Input {...props} />);
   td.verify(handleValueChange(value, td.matchers.isA(Function)), {times: 1});
 });
@@ -277,7 +278,8 @@ test('#componentDidUpdate calls setValid when isValid changes', () => {
 
 test('props.handleValueChange() is called if this.props.value updates', () => {
   const handleValueChange = td.func();
-  const props: any = {handleValueChange};
+  const foundation = {};
+  const props: any = {handleValueChange, foundation};
   const wrapper = shallow(<Input {...props} />);
   wrapper.setProps({value: 'meow'});
   td.verify(handleValueChange('meow', td.matchers.isA(Function)), {times: 1});

--- a/test/unit/text-field/Input.test.tsx
+++ b/test/unit/text-field/Input.test.tsx
@@ -438,5 +438,5 @@ test('shouldn\'t call foundation.setValue() when triggered by user', () => {
   const event = {target: {value: 'meow'}};
   wrapper.simulate('change', event);
   wrapper.setProps({value});
-  td.verify(foundation.setValue(), {times: 0});
+  td.verify(foundation.setValue(value), {times: 0});
 });

--- a/test/unit/text-field/index.test.tsx
+++ b/test/unit/text-field/index.test.tsx
@@ -628,16 +628,6 @@ test('renders textarea if textarea variant', () => {
   assert.equal(wrapper.find('textarea').length, 1);
 });
 
-test('does not render input if there is no foundation', () => {
-  const wrapper = shallow(
-    <TextField label='my label'>
-      <Input />
-    </TextField>,
-    {disableLifecycleMethods: true}
-  );
-  assert.equal(wrapper.find(Input).length, 0);
-});
-
 test('renders input after foundation is created', () => {
   const wrapper = shallow(
     <TextField label='my label'>
@@ -745,7 +735,7 @@ test('#componentWillUnmount destroys foundation', () => {
   td.verify(foundation.destroy(), {times: 1});
 });
 
-test('input component is rendered before did mount', () => {
+test('render input before component is mounted', () => {
   const wrapper = shallow<TextField<HTMLInputElement>>(
     <TextField label='hello'>
       <Input />

--- a/test/unit/text-field/index.test.tsx
+++ b/test/unit/text-field/index.test.tsx
@@ -744,3 +744,14 @@ test('#componentWillUnmount destroys foundation', () => {
   wrapper.unmount();
   td.verify(foundation.destroy(), {times: 1});
 });
+
+test('input component is rendered before did mount', () => {
+  const wrapper = shallow<TextField<HTMLInputElement>>(
+    <TextField label='hello'>
+      <Input />
+    </TextField>,
+    {disableLifecycleMethods: true}
+  );
+
+  assert.equal(wrapper.find(Input).length, 1);
+});


### PR DESCRIPTION
The `Input` component isn't being rendered on the first render (thus, not rendering on SSR) which can cause some issues for SEO and usability, such as the user being unable to type in the form while the JS hasn't run yet.

The markup I'm getting on my SSR with the latest version is

```html
<div class="mdc-text-field">
  <label class="mdc-floating-label" for="">Username</label>
  <div class="mdc-line-ripple"></div>
</div>
```

And with the changes on this PR

```html
<div class="mdc-text-field">
  <input type="text" value="" class="mdc-text-field__input" name="username" id=""/>
  <label class="mdc-floating-label" for="">Username</label>
  <div class="mdc-line-ripple"></div>
</div>
```

And the reason for that is because the `TextField` component actually controls whether or not the `Input` will be rendered, which depends on the foundation being initialized.