### PR TITLE
chore(switch): remove unused mdcw-ripple dep

### DIFF
--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@material/react-ripple": "^0.10.0",
-    "@material/ripple": "^0.41.0",
     "@material/switch": "^0.41.0",
     "classnames": "^2.2.6",
     "react": "^16.3.2"


### PR DESCRIPTION
This dependency isn't being used and, with the next release, this package would break when doing SSR because this version of `@material/ripple` contains direct reference to `HTMLElement`.