### PR TITLE
fix(list): make listitem props optional

### DIFF
--- a/packages/list/ListItem.tsx
+++ b/packages/list/ListItem.tsx
@@ -24,16 +24,16 @@ import * as React from 'react';
 import classnames from 'classnames';
 
 export interface ListItemProps<T> extends React.HTMLProps<T> {
-  className: string;
-  classNamesFromList: string[];
-  attributesFromList: object;
-  childrenTabIndex: number;
-  tabIndex: number;
-  shouldFocus: boolean;
-  shouldFollowHref: boolean;
-  shouldToggleCheckbox: boolean;
-  tag: string;
-  children: React.ReactNode;
+  className?: string;
+  classNamesFromList?: string[];
+  attributesFromList?: object;
+  childrenTabIndex?: number;
+  tabIndex?: number;
+  shouldFocus?: boolean;
+  shouldFollowHref?: boolean;
+  shouldToggleCheckbox?: boolean;
+  tag?: string;
+  children?: React.ReactNode;
 };
 
 function isAnchorElement(element: any): element is HTMLAnchorElement {

--- a/packages/ripple/index.tsx
+++ b/packages/ripple/index.tsx
@@ -51,7 +51,7 @@ export interface RippledComponentState {
 
 // props to be injected by this HOC.
 export interface InjectedProps<S, A = Element> extends RippledComponentProps<S> {
-  initRipple: React.Ref<S> | ((surface: S | null, activator?: A | null) => void);
+  initRipple?: React.Ref<S> | ((surface: S | null, activator?: A | null) => void);
 }
 
 type ActivateEventTypes<S>


### PR DESCRIPTION
related https://github.com/material-components/material-components-web-react/pull/737
fixes https://github.com/material-components/material-components-web-react/issues/734

ListItem was missed as the changes were made in the MDC Web v1 typescript update. We moved the list changes out of the latest release, which included making these optional.