### PR TITLE
chore(drawer): Update focus-trap dependency to ^4.0.2

### DIFF
--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -20,7 +20,7 @@
     "@material/drawer": "^0.41.0",
     "@material/list": "^0.41.0",
     "classnames": "^2.2.6",
-    "focus-trap": "^3.0.0",
+    "focus-trap": "^4.0.2",
     "react": "^16.4.2"
   },
   "publishConfig": {


### PR DESCRIPTION
Currently the drawer and dialog components use different focus-trap versions. This
pull request syncs them to the later one (^4.0.2)

https://github.com/material-components/material-components-web-react/issues/795