### PR TITLE
Correction to README file

### DIFF
--- a/packages/ripple/README.md
+++ b/packages/ripple/README.md
@@ -27,6 +27,7 @@ You'll also need to include these sass mixins on the element. Please also refer 
   @include mdc-ripple-surface;
   @include mdc-ripple-radius-bounded;
   @include mdc-states;
+  overflow: hidden;
 }
 ```
 

--- a/packages/ripple/README.md
+++ b/packages/ripple/README.md
@@ -20,7 +20,7 @@ import '@material/react-ripple/index.scss';
 You'll also need to include these sass mixins on the element. Please also refer to [Advanced Sass Mixins](https://github.com/material-components/material-components-web/blob/master/packages/mdc-ripple/README.md#sass-apis) to customize further.
 
 ```sass
-@import "@material/ripple/index.scss";
+@import "@material/ripple/mdc-ripple.scss";
 
 // refer to element in Javascript portion below
 .ripple-icon-component {


### PR DESCRIPTION
Hello, there is an error in this documentation. At line 23, reader is advised to add:
```js
@import "@material/ripple/index.scss";
```

This file does not exist.

User should be advised to add:

```js
@import "@material/ripple/mdc-ripple.scss";
```

Thank you
a