### PR TITLE
fix: Remove MDCTextfield Constant External

### DIFF
--- a/packages/webpack.config.js
+++ b/packages/webpack.config.js
@@ -112,7 +112,6 @@ function getJavaScriptWebpackConfig() {
           'react-dom': 'react-dom',
           'classnames': 'classnames',
           'prop-types': 'prop-types',
-          '@material/textfield/constants': `@material/textfield/constants.js`,
         },
         materialExternals,
       ),


### PR DESCRIPTION
Remove MDCTextfield Constant External from webpack.config.js

fixes #802