### PR TITLE
fix(list): memoize-one build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "stop": "./test/screenshot/stop.sh",
     "build": "npm run clean && mkdirp build && node --max_old_space_size=8192 node_modules/.bin/webpack --config packages/webpack.config.js --progress --colors",
     "capture": "MDC_COMMIT_HASH=$(git rev-parse --short HEAD) MDC_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) mocha --require ts-node/register --require babel-core/register --ui tdd --timeout 30000 test/screenshot/capture-suite.tsx",
-    "clean": "rimraf build/** build packages/**/dist/",
+    "clean": "rimraf build/** build packages/*/dist/",
     "commitmsg": "validate-commit-msg",
     "fix": "eslint --fix --ext .jsx,.js,.tsx,.ts packages test",
     "lint": "eslint --ext .jsx,.js,.tsx,.ts packages test",

--- a/packages/list/index.tsx
+++ b/packages/list/index.tsx
@@ -25,7 +25,8 @@ import classnames from 'classnames';
 import {MDCListFoundation} from '@material/list/foundation';
 import {MDCListIndex} from '@material/list/types';
 import {MDCListAdapter} from '@material/list/adapter';
-import memoizeOne from 'memoize-one';
+// @ts-ignore @types cannot be used on dist files
+import memoizeOne from 'memoize-one/dist/memoize-one.cjs.js';
 
 import ListItem, {ListItemProps} from './ListItem'; // eslint-disable-line no-unused-vars
 import ListItemGraphic from './ListItemGraphic';


### PR DESCRIPTION
`memoize-one` cannot be resolved because of how it exports it's files. This lead to unit test failures. Also when running `npm run build`, the `clean` step would delete the `memoize-one/dist/` directory, resulting in a build failure. 