### PR TITLE
feat(floating-label): use cssClasses & add methods

### DIFF
--- a/packages/floating-label/index.tsx
+++ b/packages/floating-label/index.tsx
@@ -25,6 +25,8 @@ import classnames from 'classnames';
 import {MDCFloatingLabelFoundation} from '@material/floating-label/foundation';
 import {MDCFloatingLabelAdapter} from '@material/floating-label/adapter';
 
+const cssClasses = MDCFloatingLabelFoundation.cssClasses;
+
 export interface FloatingLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   className?: string;
   handleWidthChange?: (width: number) => void;
@@ -80,7 +82,7 @@ export default class FloatingLabel extends React.Component<
   get classes() {
     const {classList} = this.state;
     const {className} = this.props;
-    return classnames('mdc-floating-label', Array.from(classList), className);
+    return classnames(cssClasses.ROOT, Array.from(classList), className);
   }
 
   get adapter(): MDCFloatingLabelAdapter {
@@ -118,8 +120,7 @@ export default class FloatingLabel extends React.Component<
   };
 
   onShakeEnd = () => {
-    const {LABEL_SHAKE} = MDCFloatingLabelFoundation.cssClasses;
-    this.removeClassFromClassList(LABEL_SHAKE);
+    this.removeClassFromClassList(cssClasses.LABEL_SHAKE);
   };
 
   render() {

--- a/packages/floating-label/index.tsx
+++ b/packages/floating-label/index.tsx
@@ -102,9 +102,17 @@ export default class FloatingLabel extends React.Component<
     };
   }
 
-  // must be called via ref
-  shake = () => {
-    this.foundation.shake(true);
+  shake = (shouldShake: boolean) => {
+    this.foundation.shake(shouldShake);
+  };
+
+  float = (shouldFloat: boolean) => {
+    this.foundation.float(shouldFloat);
+  };
+
+  getWidth = () => {
+    const labelElement = this.labelElement.current;
+    return labelElement ? labelElement.offsetWidth : -1;
   };
 
   removeClassFromClassList = (className: string) => {
@@ -115,7 +123,7 @@ export default class FloatingLabel extends React.Component<
 
   handleWidthChange = () => {
     if (this.props.handleWidthChange && this.labelElement.current) {
-      this.props.handleWidthChange(this.labelElement.current.offsetWidth);
+      this.props.handleWidthChange(this.getWidth());
     }
   };
 

--- a/packages/floating-label/index.tsx
+++ b/packages/floating-label/index.tsx
@@ -111,8 +111,7 @@ export default class FloatingLabel extends React.Component<
   };
 
   getWidth = () => {
-    const labelElement = this.labelElement.current;
-    return labelElement ? labelElement.offsetWidth : -1;
+    return this.foundation.getWidth();
   };
 
   removeClassFromClassList = (className: string) => {
@@ -123,7 +122,7 @@ export default class FloatingLabel extends React.Component<
 
   handleWidthChange = () => {
     if (this.props.handleWidthChange && this.labelElement.current) {
-      this.props.handleWidthChange(this.getWidth());
+      this.props.handleWidthChange(this.labelElement.current.offsetWidth);
     }
   };
 

--- a/packages/text-field/index.tsx
+++ b/packages/text-field/index.tsx
@@ -245,7 +245,7 @@ class TextField<T extends HTMLElement = HTMLInputElement> extends React.Componen
         const {floatingLabelElement: floatingLabel} = this;
         if (!shakeLabel) return;
         if (floatingLabel && floatingLabel.current) {
-          floatingLabel.current.shake();
+          floatingLabel.current.shake(true);
         }
       },
       floatLabel: (labelIsFloated: boolean) => this.setState({labelIsFloated}),

--- a/test/unit/text-field/index.test.tsx
+++ b/test/unit/text-field/index.test.tsx
@@ -239,7 +239,7 @@ test('#adapter.label.shakeLabel calls floatingLabelElement shake', () => {
     }),
   }) as React.RefObject<FloatingLabel>;
   wrapper.instance().adapter.shakeLabel(true);
-  td.verify(wrapper.instance().floatingLabelElement.current!.shake(), {
+  td.verify(wrapper.instance().floatingLabelElement.current!.shake(true), {
     times: 1,
   });
 });
@@ -256,7 +256,7 @@ test('#adapter.label.shakeLabel does not call floatingLabelElement shake if fals
     }),
   }));
   wrapper.instance().adapter.shakeLabel(false);
-  td.verify(wrapper.instance().floatingLabelElement.current!.shake(), {
+  td.verify(wrapper.instance().floatingLabelElement.current!.shake(true), {
     times: 0,
   });
 });


### PR DESCRIPTION
related to #827

Following this document(https://github.com/material-components/material-components-web/tree/master/packages/mdc-floating-label#mdcfloatinglabel-properties-and-methods)

I added two methods:
 - float(shouldFloat: boolean) => void
 - getWidth() => number

And change one method:
 - shake(shouldShake: boolean) => void

Shake method has already been declared but no argument.
Maybe I don't understand what the comment is meaning.
Check this please :)