### PR TITLE
feat(text-field): add placeholder property

### DIFF
--- a/packages/text-field/Input.tsx
+++ b/packages/text-field/Input.tsx
@@ -38,6 +38,7 @@ export interface InputProps<T extends HTMLElement = HTMLInputElement> {
   setDisabled?: (disabled: boolean) => void;
   setInputId?: (id: string | number) => void;
   handleFocusChange?: (isFocused: boolean) => void;
+  placeholder?: string;
 };
 
 type InputElementProps = Exclude<React.HTMLProps<HTMLInputElement>, 'ref'>;
@@ -268,6 +269,7 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       onMouseDown,
       onTouchStart,
       onChange,
+      placeholder,
       /* eslint-enable no-unused-vars */
       ...otherProps
     } = this.props;
@@ -282,6 +284,7 @@ export default class Input<T extends HTMLElement = HTMLInputElement> extends Rea
       value: value,
       ref: this.inputElement_,
       className: this.classes,
+      placeholder: placeholder,
     }, otherProps);
 
     if (inputType === 'input') {

--- a/packages/text-field/index.tsx
+++ b/packages/text-field/index.tsx
@@ -58,6 +58,7 @@ export interface Props<T extends HTMLElement = HTMLInputElement> {
   onTrailingIconSelect?: () => void;
   textarea?: boolean;
   trailingIcon?: React.ReactElement<React.HTMLProps<HTMLOrSVGElement>>;
+  floatLabel?: boolean;
 };
 
 type TextFieldProps<T extends HTMLElement = HTMLInputElement> = Props<T> & React.HTMLProps<HTMLDivElement>;
@@ -91,6 +92,7 @@ class TextField<T extends HTMLElement = HTMLInputElement> extends React.Componen
     notchedOutlineClassName: '',
     outlined: false,
     textarea: false,
+    floatLabel: true,
   };
 
   constructor(props: TextFieldProps<T>) {
@@ -145,6 +147,7 @@ class TextField<T extends HTMLElement = HTMLInputElement> extends React.Componen
       textarea,
       trailingIcon,
       leadingIcon,
+      floatLabel,
     } = this.props;
 
     return classnames(cssClasses.ROOT, Array.from(classList), className, {
@@ -158,7 +161,7 @@ class TextField<T extends HTMLElement = HTMLInputElement> extends React.Componen
       // TODO change literal to constant
       'mdc-text-field--fullwidth': fullWidth,
       'mdc-text-field--with-trailing-icon': trailingIcon,
-      'mdc-text-field--no-label': !this.labelAdapter.hasLabel(),
+      'mdc-text-field--no-label': !this.labelAdapter.hasLabel() || !floatLabel,
     });
   }
 
@@ -180,6 +183,7 @@ class TextField<T extends HTMLElement = HTMLInputElement> extends React.Componen
       outlined,
       textarea,
       trailingIcon,
+      floatLabel,
       /* eslint-enable no-unused-vars */
       ...otherProps
     } = this.props;
@@ -288,6 +292,7 @@ class TextField<T extends HTMLElement = HTMLInputElement> extends React.Componen
         this.inputComponent_ = input;
       },
       inputType: this.props.textarea ? 'textarea' : 'input',
+      placeholder: !this.props.floatLabel ? this.props.label : null,
     });
   }
 
@@ -304,6 +309,7 @@ class TextField<T extends HTMLElement = HTMLInputElement> extends React.Componen
       leadingIcon,
       trailingIcon,
       textarea,
+      floatLabel,
     } = this.props;
     const {foundation} = this.state;
 
@@ -319,7 +325,7 @@ class TextField<T extends HTMLElement = HTMLInputElement> extends React.Componen
           {leadingIcon ? this.renderIcon(leadingIcon, onLeadingIconSelect) : null}
           {this.renderInput()}
           {this.notchedOutlineAdapter.hasOutline() ? this.renderNotchedOutline() : <React.Fragment>
-            {this.labelAdapter.hasLabel() ? this.renderLabel() : null}
+            {this.labelAdapter.hasLabel() && floatLabel ? this.renderLabel() : null}
             {!textarea && !fullWidth ? this.renderLineRipple() : null}
           </React.Fragment>}
           {trailingIcon ? this.renderIcon(trailingIcon, onTrailingIconSelect) : null}

--- a/test/screenshot/text-field/TextFieldPermutations.tsx
+++ b/test/screenshot/text-field/TextFieldPermutations.tsx
@@ -9,6 +9,7 @@ import {
   getHelperKeyText,
   HelperTextMapType,
   isValidationMsg,
+  floatLabelMap,
 } from './attributesMap';
 import TestField from './TestTextField';
 
@@ -22,38 +23,43 @@ const textFields = (variantProps: {variant?: string}) => {
       return rtlMap.map((isRtl: {isRtl?: boolean}) => {
         return requiredMap.map((isRequired: {required?: boolean}) => {
           return disabledMap.map((disabled: {disabled?: boolean}) => {
-            return helperTextMap.map((helperText: HelperTextMapType | {}) => {
-              const isValidationTextField = isValidationMsg(helperText);
-              const value = !isValidationTextField
-                ? {value: null}
-                : {value: ''};
-              const iconKey = Object.keys(icon)[0] || '';
-              const denseKey = Object.keys(dense)[0] || '';
-              const rtlKey = Object.keys(isRtl)[0] || '';
-              const disabledKey = Object.keys(disabled)[0] || '';
-              const isRequiredKey = Object.keys(isRequired)[0] || '';
-              const helperTextKey = getHelperKeyText(
-                helperText,
-                isValidationTextField
-              );
-              const props = Object.assign(
-                {},
-                variantProps,
-                icon,
-                dense,
-                disabled,
-                helperText,
-                isRequired,
-                isRtl,
-                value
-              );
-              const key = `${iconKey}-${denseKey}-${disabledKey}-${helperTextKey}-${isRequiredKey}--${rtlKey}`;
-              const hasIcon =
-                iconKey === 'leadingIcon' || iconKey === 'trailingIcon';
-              if (hasIcon && variantProps.variant === 'fullWidth') {
-                return;
-              }
-              return <TestField {...props} key={key} id={key} />;
+            return floatLabelMap.map((floatLabel: {floatLabel?: boolean}) => {
+              return helperTextMap.map((helperText: HelperTextMapType | {}) => {
+                const isValidationTextField = isValidationMsg(helperText);
+                const value = !isValidationTextField
+                  ? {value: null}
+                  : {value: ''};
+                const iconKey = Object.keys(icon)[0] || '';
+                const denseKey = Object.keys(dense)[0] || '';
+                const rtlKey = Object.keys(isRtl)[0] || '';
+                const disabledKey = Object.keys(disabled)[0] || '';
+                const isRequiredKey = Object.keys(isRequired)[0] || '';
+                const floatLabelKey = Object.keys(floatLabel)[0] || '';
+                const helperTextKey = getHelperKeyText(
+                  helperText,
+                  isValidationTextField
+                );
+                const props = Object.assign(
+                  {},
+                  variantProps,
+                  icon,
+                  dense,
+                  disabled,
+                  helperText,
+                  isRequired,
+                  isRtl,
+                  value,
+                  floatLabel,
+                );
+                const key = `${iconKey}-${denseKey}-${disabledKey}-${floatLabelKey}-${helperTextKey}-${isRequiredKey}` +
+                            `--${rtlKey}`;
+                const hasIcon =
+                          iconKey === 'leadingIcon' || iconKey === 'trailingIcon';
+                if (hasIcon && variantProps.variant === 'fullWidth') {
+                  return;
+                }
+                return <TestField {...props} key={key} id={key} />;
+              });
             });
           });
         });

--- a/test/screenshot/text-field/attributesMap.tsx
+++ b/test/screenshot/text-field/attributesMap.tsx
@@ -18,6 +18,7 @@ const denseMap = [{}, {dense: true}];
 const rtlMap = [{}, {isRtl: true}];
 const requiredMap = [{}, {required: true}];
 const disabledMap = [{}, {disabled: true}];
+const floatLabelMap = [{}, {floatLabel: false}];
 const helperTextMap = [
   {},
   {helperText: <HelperText persistent>Help me</HelperText>},
@@ -51,4 +52,5 @@ export {
   helperTextMap,
   getHelperKeyText,
   isValidationMsg,
+  floatLabelMap,
 };


### PR DESCRIPTION
related to #224

I opened this PR to start a discussion around issue #224 that was opened last year. This feature branch added support for the `mdc-text-field--no-label` class, so it seems like a good time to support placeholder text when a label isn't present. The examples for text fields without labels on [Material IO](https://material.io/design/components/text-fields.html) display text fields without labels still having placeholder text.