### PR TITLE
fix(fab): Made initRipple and unbounded props optional

### DIFF
--- a/packages/fab/index.tsx
+++ b/packages/fab/index.tsx
@@ -33,8 +33,8 @@ export interface FabProps extends InjectedProps<HTMLButtonElement>,
     icon?: React.ReactElement<HTMLElement>;
     textLabel?: string;
     className?: string;
-    initRipple: React.Ref<HTMLButtonElement>;
-    unbounded: boolean;
+    initRipple?: React.Ref<HTMLButtonElement>;
+    unbounded?: boolean;
 }
 
 const Icon: React.FunctionComponent<{icon?: React.ReactElement<HTMLElement>}> = ({icon}) => {


### PR DESCRIPTION
Reopening #810 

> This PR is a follow up to this conversation: b62c36f#r33164756
> 
> `initRipple` and `unbounded` props should be optional.