### PR TITLE
Enable choice between icon first or last in fabs

### DIFF
--- a/packages/fab/README.md
+++ b/packages/fab/README.md
@@ -51,6 +51,7 @@ exited | Boolean | When true animates the FAB out of view. When this false, the 
 mini | Boolean |  Enables the mini variant. 
 icon | Element | The icon.
 textLabel | String | The label, which makes the FAB extended.
+iconFirst | Boolean | When false, the text label is rendered in front of the icon. Defaults to true.
 
 ## Sass Mixins
 

--- a/packages/fab/index.tsx
+++ b/packages/fab/index.tsx
@@ -34,6 +34,7 @@ export interface FabProps
   icon?: React.ReactElement<HTMLElement>;
   textLabel?: string;
   className?: string;
+  iconFirst: boolean;
   initRipple?: React.Ref<HTMLButtonElement>;
   unbounded?: boolean;
 }
@@ -66,6 +67,7 @@ export const Fab: React.FunctionComponent<
   mini = false,
   icon,
   textLabel = '',
+  iconFirst = true,
   className = '',
   initRipple = () => {},
   unbounded, // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -78,10 +80,18 @@ export const Fab: React.FunctionComponent<
     [CSS_CLASSES.EXITED]: exited,
   });
 
+  const children = [
+    <Icon icon={icon} />,
+    <TextLabel textLabel={textLabel} />
+  ];
+
+  if (iconFirst === false) {
+    children.reverse();
+  }
+
   return (
     <button className={classes} ref={initRipple} {...otherProps}>
-      <Icon icon={icon} />
-      <TextLabel textLabel={textLabel} />
+      {children}
     </button>
   );
 };

--- a/packages/fab/index.tsx
+++ b/packages/fab/index.tsx
@@ -80,18 +80,11 @@ export const Fab: React.FunctionComponent<
     [CSS_CLASSES.EXITED]: exited,
   });
 
-  const children = [
-    <Icon icon={icon} />,
-    <TextLabel textLabel={textLabel} />
-  ];
-
-  if (iconFirst === false) {
-    children.reverse();
-  }
-
   return (
     <button className={classes} ref={initRipple} {...otherProps}>
-      {children}
+      {iconFirst === true && <Icon icon={icon} />}
+      <TextLabel textLabel={textLabel} />
+      {iconFirst === false && <Icon icon={icon} />}
     </button>
   );
 };

--- a/packages/fab/index.tsx
+++ b/packages/fab/index.tsx
@@ -34,7 +34,7 @@ export interface FabProps
   icon?: React.ReactElement<HTMLElement>;
   textLabel?: string;
   className?: string;
-  iconFirst: boolean;
+  iconFirst?: boolean;
   initRipple?: React.Ref<HTMLButtonElement>;
   unbounded?: boolean;
 }

--- a/test/unit/fab/index.test.tsx
+++ b/test/unit/fab/index.test.tsx
@@ -51,6 +51,27 @@ test('text label is rendered', () => {
   const icon = <i className='test-action-icon-1' />;
   const wrapper = mount(<Fab icon={icon} textLabel='Text Label' />);
   assert.isTrue(wrapper.find('.mdc-fab__label').length === 1);
+  assert.isTrue(
+    wrapper
+      .find('.mdc-fab')
+      .childAt(0)
+      .childAt(0)
+      .hasClass('mdc-fab__icon')
+  );
+});
+
+test('text label is rendered before icon', () => {
+  const icon = <i className='test-action-icon-1' />;
+  const wrapper = mount(
+    <Fab icon={icon} textLabel='Text Label' iconFirst={false} />
+  );
+  assert.isTrue(
+    wrapper
+      .find('.mdc-fab')
+      .childAt(0)
+      .childAt(0)
+      .hasClass('mdc-fab__label')
+  );
 });
 
 test('i tag is rendered', () => {


### PR DESCRIPTION
The extended fab in MDC for web let you decide whether the label or the icon comes first based on ordering of elements (https://github.com/material-components/material-components-web/tree/master/packages/mdc-fab). The React version isn't quite so flexible.

In this version, I have introduced a new property called `iconFirst` that defaults to `true`, which is currently the default behaviour.

When `iconFirst` is false, the text label span is written first, and so appears in front of the icon.