### PR TITLE
fix(ripple): focus style alive when disabled

### DIFF
--- a/packages/ripple/index.tsx
+++ b/packages/ripple/index.tsx
@@ -29,6 +29,8 @@ import {supportsCssVariables, applyPassive} from '@material/ripple/util';
 import {SpecificEventListener} from '@material/base/types';
 import {matches} from '@material/dom/ponyfill';
 
+const cssClasses = MDCRippleFoundation.cssClasses;
+
 export interface RippledComponentProps<T> {
   unbounded?: boolean;
   disabled?: boolean;
@@ -110,6 +112,7 @@ export function withRipple<
       RippledComponentState
     >
     implements RippledComponentInterface<Surface, Activator> {
+    adapter!: MDCRippleAdapter;
     foundation!: MDCRippleFoundation;
     isComponentMounted: boolean = true;
     isTouched: boolean = false;
@@ -146,6 +149,12 @@ export function withRipple<
       }
     }
 
+    componentDidUpdate(prevProps: P) {
+      if (this.props.disabled !== prevProps.disabled && this.props.disabled) {
+        this.disabledRipplePostProcessor();
+      }
+    }
+
     componentWillUnmount() {
       if (this.foundation) {
         this.isComponentMounted = false;
@@ -157,8 +166,8 @@ export function withRipple<
     // activator: This element is used to detect whether to activate the ripple. If this is not
     // provided, the ripple surface will be used to detect activation.
     initializeFoundation = (surface: Surface, activator?: Activator) => {
-      const adapter = this.createAdapter(surface, activator);
-      this.foundation = new MDCRippleFoundation(adapter);
+      this.adapter = this.createAdapter(surface, activator);
+      this.foundation = new MDCRippleFoundation(this.adapter);
       this.foundation.init();
     };
 
@@ -323,6 +332,10 @@ export function withRipple<
           style: updatedStyle,
         });
       });
+    };
+
+    disabledRipplePostProcessor = () => {
+      this.adapter.removeClass(cssClasses.BG_FOCUSED);
     };
 
     get classes() {

--- a/packages/ripple/index.tsx
+++ b/packages/ripple/index.tsx
@@ -29,8 +29,6 @@ import {supportsCssVariables, applyPassive} from '@material/ripple/util';
 import {SpecificEventListener} from '@material/base/types';
 import {matches} from '@material/dom/ponyfill';
 
-const cssClasses = MDCRippleFoundation.cssClasses;
-
 export interface RippledComponentProps<T> {
   unbounded?: boolean;
   disabled?: boolean;
@@ -112,7 +110,6 @@ export function withRipple<
       RippledComponentState
     >
     implements RippledComponentInterface<Surface, Activator> {
-    adapter!: MDCRippleAdapter;
     foundation!: MDCRippleFoundation;
     isComponentMounted: boolean = true;
     isTouched: boolean = false;
@@ -155,12 +152,6 @@ export function withRipple<
       }
     }
 
-    componentDidUpdate(prevProps: P) {
-      if (this.props.disabled !== prevProps.disabled && this.props.disabled) {
-        this.disabledRipplePostProcessor();
-      }
-    }
-
     componentWillUnmount() {
       if (this.foundation) {
         this.isComponentMounted = false;
@@ -172,8 +163,8 @@ export function withRipple<
     // activator: This element is used to detect whether to activate the ripple. If this is not
     // provided, the ripple surface will be used to detect activation.
     initializeFoundation = (surface: Surface, activator?: Activator) => {
-      this.adapter = this.createAdapter(surface, activator);
-      this.foundation = new MDCRippleFoundation(this.adapter);
+      const adapter = this.createAdapter(surface, activator);
+      this.foundation = new MDCRippleFoundation(adapter);
       this.foundation.init();
     };
 
@@ -338,10 +329,6 @@ export function withRipple<
           style: updatedStyle,
         });
       });
-    };
-
-    disabledRipplePostProcessor = () => {
-      this.adapter.removeClass(cssClasses.BG_FOCUSED);
     };
 
     get classes() {

--- a/packages/ripple/index.tsx
+++ b/packages/ripple/index.tsx
@@ -151,6 +151,12 @@ export function withRipple<
 
     componentDidUpdate(prevProps: P) {
       if (this.props.disabled !== prevProps.disabled && this.props.disabled) {
+        this.foundation.handleBlur();
+      }
+    }
+
+    componentDidUpdate(prevProps: P) {
+      if (this.props.disabled !== prevProps.disabled && this.props.disabled) {
         this.disabledRipplePostProcessor();
       }
     }

--- a/test/unit/ripple/index.test.tsx
+++ b/test/unit/ripple/index.test.tsx
@@ -5,7 +5,9 @@ import {MDCRippleFoundation} from '@material/ripple/foundation';
 import {MDCRippleAdapter} from '@material/ripple/adapter';
 import {SpecificEventListener} from '@material/base/types';
 import {mount} from 'enzyme';
-import {withRipple, InjectedProps} from '../../../packages/ripple/index';
+
+import Button from '../../../packages/button';
+import {withRipple, InjectedProps} from '../../../packages/ripple';
 import {createMockRaf} from '../helpers/raf';
 import {coerceForTesting} from '../helpers/types';
 
@@ -479,4 +481,13 @@ test('unmounting component does not throw errors', (done) => {
     );
     done();
   });
+});
+
+test('handleBlur is called when disabled is being true', () => {
+  const wrapper = mount(<Button />);
+  const foundation = coerceForTesting<RippledComponent>(wrapper.instance())
+    .foundation;
+  foundation.handleBlur = td.func<() => void>();
+  wrapper.setProps({disabled: true});
+  td.verify(foundation.handleBlur(), {times: 1});
 });


### PR DESCRIPTION
fixes #916

@poying
I wrote it pretty much like your code.
But I'm not call `handleBlur` and I made `disabledRipplePostProcessor`.
Because there are some possibility that adds other code in`handleBlur`.
If you have any other opinion, tell me about that!

@moog16 
I added `adapter` to a member variable.
Existing member variables do not have an `adapter`, is there any special reason??

If both of you are okay, I'll write unit test code :)