### PR TITLE
fix(list): Remove selected & activated from prop spread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# [](https://github.com/material-components/material-components-web-react/compare/v0.13.2...v) (2019-06-25)
+# [0.14.1](https://github.com/material-components/material-components-web-react/compare/v0.14.0...v0.14.1) (2019-07-02)
+
+
+### Bug Fixes
+
+* **infrastructure:** fix SSR support for webpack4 update ([#956](https://github.com/material-components/material-components-web-react/issues/956)) ([5d3a89d](https://github.com/material-components/material-components-web-react/commit/5d3a89d))
+
+
+
+# [0.14.0](https://github.com/material-components/material-components-web-react/compare/v0.13.2...v0.14.0) (2019-06-25)
 
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.14.0"
+  "version": "0.14.1"
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-button",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Button",
   "license": "MIT",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@material/button": "^1.1.0",
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "classnames": "^2.2.6"
   },
   "publishConfig": {

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-card",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Card",
   "license": "MIT",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@material/card": "^2.1.1",
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "classnames": "^2.2.6"
   },
   "publishConfig": {

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-checkbox",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Checkbox",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@material/checkbox": "^2.1.1",
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "classnames": "^2.2.6"
   },
   "publishConfig": {

--- a/packages/chips/package.json
+++ b/packages/chips/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-chips",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Chips",
   "license": "MIT",
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@material/chips": "^2.3.0",
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "classnames": "^2.2.6",
     "react-is": "^16.8.6"
   },

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-dialog",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Dialog",
   "license": "MIT",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@material/dialog": "^2.2.0",
     "@material/dom": "^1.0.0",
-    "@material/react-button": "^0.14.0",
+    "@material/react-button": "^0.14.1",
     "classnames": "^2.2.6",
     "focus-trap": "^5.0.0"
   },

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-drawer",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Drawer",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-fab",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Floating Action Button (FAB)",
   "license": "MIT",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@material/fab": "^2.1.1",
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "classnames": "^2.2.6"
   },
   "publishConfig": {

--- a/packages/floating-label/package.json
+++ b/packages/floating-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-floating-label",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Floating Label",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-icon-button",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Icon Button",
   "license": "Apache-2.0",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@material/icon-button": "^2.1.1",
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "classnames": "^2.2.6"
   },
   "publishConfig": {

--- a/packages/layout-grid/package.json
+++ b/packages/layout-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-layout-grid",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Layout Grid",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/line-ripple/package.json
+++ b/packages/line-ripple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-line-ripple",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Line Ripple",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-linear-progress",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Linear Progress",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/list/ListItem.tsx
+++ b/packages/list/ListItem.tsx
@@ -186,6 +186,8 @@ export class ListItemBase<
       initRipple,
       checkboxList,
       radioList,
+      selected,
+      activated,
       onDestroy,
       onClick,
       onKeyDown,

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-list",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React List",
   "license": "MIT",
   "main": "dist/index.js",
@@ -21,9 +21,9 @@
   "dependencies": {
     "@material/dom": "^1.1.0",
     "@material/list": "^1.0.0",
-    "@material/react-checkbox": "^0.14.0",
-    "@material/react-radio": "^0.14.0",
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-checkbox": "^0.14.1",
+    "@material/react-radio": "^0.14.1",
+    "@material/react-ripple": "^0.14.1",
     "classnames": "^2.2.6",
     "memoize-one": "^5.0.4"
   },

--- a/packages/material-icon/package.json
+++ b/packages/material-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-material-icon",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Material Icon",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "react": "^16.4.2"
   },
   "dependencies": {
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "classnames": "^2.2.6"
   },
   "publishConfig": {

--- a/packages/menu-surface/package.json
+++ b/packages/menu-surface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-menu-surface",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Menu Surface",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-menu",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Menu",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@material/menu": "^1.1.0",
-    "@material/react-list": "^0.14.0",
-    "@material/react-menu-surface": "^0.14.0",
+    "@material/react-list": "^0.14.1",
+    "@material/react-menu-surface": "^0.14.1",
     "classnames": "^2.2.6"
   },
   "publishConfig": {

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-notched-outline",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Componens React Notched Outline",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-radio",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Componens React Radio",
   "license": "MIT",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   "dependencies": {
     "@material/form-field": "^0.41.0",
     "@material/radio": "^1.1.0",
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "classnames": "^2.2.6"
   },
   "publishConfig": {

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-ripple",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Ripple",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-select",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Select",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,11 +19,11 @@
     "react": "^16.4.2"
   },
   "dependencies": {
-    "@material/react-floating-label": "^0.14.0",
-    "@material/react-line-ripple": "^0.14.0",
-    "@material/react-menu": "^0.14.0",
-    "@material/react-menu-surface": "^0.14.0",
-    "@material/react-notched-outline": "^0.14.0",
+    "@material/react-floating-label": "^0.14.1",
+    "@material/react-line-ripple": "^0.14.1",
+    "@material/react-menu": "^0.14.1",
+    "@material/react-menu-surface": "^0.14.1",
+    "@material/react-notched-outline": "^0.14.1",
     "@material/select": "^1.1.1",
     "classnames": "^2.2.6"
   },

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-snackbar",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Snackbar",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-switch",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Switch",
   "license": "MIT",
   "main": "dist/index.js",
@@ -19,7 +19,7 @@
     "react": "^16.4.2"
   },
   "dependencies": {
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "@material/switch": "^1.0.0",
     "classnames": "^2.2.6"
   },

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-tab-bar",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Tab Bar",
   "license": "Apache-2.0",
   "main": "dist/index.js",
@@ -21,8 +21,8 @@
     "react": "^16.4.2"
   },
   "dependencies": {
-    "@material/react-tab": "^0.14.0",
-    "@material/react-tab-scroller": "^0.14.0",
+    "@material/react-tab": "^0.14.1",
+    "@material/react-tab-scroller": "^0.14.1",
     "@material/tab-bar": "^1.0.0",
     "classnames": "^2.2.6"
   },

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-tab-indicator",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Tab Indicator",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-tab-scroller",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Tab Scroller",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-tab",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Tab",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,8 +20,8 @@
     "react": "^16.4.2"
   },
   "dependencies": {
-    "@material/react-ripple": "^0.14.0",
-    "@material/react-tab-indicator": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
+    "@material/react-tab-indicator": "^0.14.1",
     "@material/tab": "^1.0.0",
     "classnames": "^2.2.6"
   },

--- a/packages/text-field/package.json
+++ b/packages/text-field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-text-field",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Text Field",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,9 +20,9 @@
     "react": "^16.4.2"
   },
   "dependencies": {
-    "@material/react-floating-label": "^0.14.0",
-    "@material/react-line-ripple": "^0.14.0",
-    "@material/react-notched-outline": "^0.14.0",
+    "@material/react-floating-label": "^0.14.1",
+    "@material/react-line-ripple": "^0.14.1",
+    "@material/react-notched-outline": "^0.14.1",
     "@material/textfield": "^2.3.1",
     "classnames": "^2.2.6"
   },

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-top-app-bar",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Top App Bar",
   "license": "MIT",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
     "react": "^16.4.2"
   },
   "dependencies": {
-    "@material/react-ripple": "^0.14.0",
+    "@material/react-ripple": "^0.14.1",
     "@material/top-app-bar": "^1.1.0",
     "classnames": "^2.2.6"
   },

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material/react-typography",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Material Components React Typography",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/webpack.config.js
+++ b/packages/webpack.config.js
@@ -75,6 +75,7 @@ function getCommonWebpackParams({isCss} = {}) {
       path: getAbsolutePath('../build'),
       filename: `${filename}${isCss ? '.css' : ''}.js`,
       libraryTarget: 'umd',
+      globalObject: `typeof self !== 'undefined' ? self : this`,
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],


### PR DESCRIPTION
`selected` and `activated` are boolean props that toggle class names. They shouldn't be passed down with prop spread. In the case of `activated`, this triggers a React console message.

There are no tests because I didn't see any other tests checking that other props are not rendered.