### PR TITLE
fix(surface): Allow ref null type

### DIFF
--- a/packages/menu-surface/index.tsx
+++ b/packages/menu-surface/index.tsx
@@ -29,7 +29,7 @@ import {Corner} from '@material/menu-surface/index';
 import {MDCMenuDistance} from '@material/menu-surface/types';
 
 export interface MenuSurfaceProps extends React.HTMLProps<HTMLDivElement> {
-  anchorElement?: HTMLElement;
+  anchorElement?: HTMLElement | null;
   anchorCorner?: number;
   anchorMargin?: {
     top?: number;


### PR DESCRIPTION
Refs return `HTMLElement | null`. This allows TS users to avoid the following:
```js
anchorElement={anchor.current || undefined}
```
Should be no change in behavior.