### PR TITLE
feat(text-field): Spread HelperText props

### DIFF
--- a/packages/text-field/helper-text/index.tsx
+++ b/packages/text-field/helper-text/index.tsx
@@ -26,7 +26,7 @@ import {MDCTextFieldHelperTextFoundation} from '@material/textfield/helper-text/
 
 const cssClasses = MDCTextFieldHelperTextFoundation.cssClasses;
 
-export interface HelperTextProps {
+export interface HelperTextProps extends React.HTMLProps<HTMLParagraphElement> {
   'aria-hidden'?: boolean;
   children: React.ReactNode;
   className?: string;
@@ -135,13 +135,29 @@ export default class HelperText extends React.Component<
   }
 
   render() {
+    const {
+      children,
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      'aria-hidden': ariaHidden,
+      className,
+      isValid,
+      isValidationMessage,
+      persistent,
+      role,
+      showToScreenReader,
+      validation,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      ...otherProps
+    } = this.props;
+
     return (
       <p
         className={this.classes}
         role={this.state.role}
         aria-hidden={this.state['aria-hidden']}
+        {...otherProps}
       >
-        {this.props.children}
+        {children}
       </p>
     );
   }

--- a/test/unit/text-field/helper-text/index.test.tsx
+++ b/test/unit/text-field/helper-text/index.test.tsx
@@ -74,6 +74,14 @@ test('sets validity to false if props.isValid is initially false', () => {
   );
   assert.equal(wrapper.state().role, undefined);
 });
+
+test('spreads other props onto paragraph element', () => {
+  const wrapper = shallow<HelperText>(
+    <HelperText id='description'>Helper Text</HelperText>
+  );
+  assert.equal(wrapper.find('p').prop('id'), 'description');
+});
+
 test(
   '#componentDidUpdate calls #foundation.showToScreenReader if ' +
     'props.showToScreenReader updates',


### PR DESCRIPTION
I need to set an id on the helper text to link via `aria-describedby`. select/HelperText already supports this via prop spreading so I updated text-field/HelperText to do the same.

https://github.com/material-components/material-components-web-react/blob/master/packages/select/helper-text/index.tsx#L135