### PR TITLE
fix(list): meta doesn't work with some element

### DIFF
--- a/packages/list/ListItemMeta.tsx
+++ b/packages/list/ListItemMeta.tsx
@@ -40,7 +40,7 @@ const ListItemMeta: React.FunctionComponent<ListItemMetaProps> = ({
   if (typeof meta === 'string') {
     metaElement = <span>{meta}</span>;
   } else {
-    metaElement = meta;
+    metaElement = <div>{meta}</div>;
   }
   const metaProps = {
     className: classnames(


### PR DESCRIPTION
Trailing with meta doesn't work with some Element. 
For exemple, if I try to create a a list with some radiobutton (on the right) with this code :
```
<ListItem key={index}>
  <ListItemText primaryText={item} />
  <ListItemMeta meta={<Radio>
    <NativeRadioControl
      name={item}
      {...}
    />
  </Radio>} />
</ListItem>
```
The css class **mdc-list-item__meta** is not present in the source code, so the element is not placed on right.