### PR TITLE
docs: MDC-React is no longer under active development

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > In order to increase our focus on implementing our core, framework-independent libraries ([MDC-Web](https://github.com/material-components/material-components-web) and [MWC](https://github.com/material-components/material-components-web-components)), we’re passing the Material+React baton back to the community. That means Material Design will no longer be updating and maintaining this repo. We recommend that you switch to another implementation and keep building beautiful, usable apps based on Material Design. Thanks for being part of the project!
 
-MDC React is the official implementation of Google's Material Design Components. It is a wrapper library for [MDC Web](https://github.com/material-components/material-components-web). Please refer to our [MDC Web Catalog](https://material-components.github.io/material-components-web-catalog/#/) to play and interact with the Components.
+MDC React was an official implementation of Google's Material Design components for React. It is a wrapper library for [MDC Web](https://github.com/material-components/material-components-web). Please refer to our [MDC Web Catalog](https://material-components.github.io/material-components-web-catalog/#/) to play and interact with the Components.
 
 ![mpmgq9h6b9x](https://user-images.githubusercontent.com/579873/44939654-d8fdfd80-ad3b-11e8-9b64-6244cb5e6886.png)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 # Material Components for React (MDC React)
 
+> NOTE: MDC-React is no longer under active development
+
+> We created MDC-React in 2018 to implement the updated Material Design guidelines.  Since then, the open-source React community has embraced the new guidelines and created a number of excellent unofficial implementations. See [Material Design Components - Web Framework Wrappers](https://github.com/material-components/material-components-web/blob/master/docs/framework-wrappers.md) for a partial list.
+
+> In order to increase our focus on implementing our core, framework-independent libraries ([MDC-Web](https://github.com/material-components/material-components-web) and [MWC](https://github.com/material-components/material-components-web-components)), we’re passing the Material+React baton back to the community. That means Material Design will no longer be updating and maintaining this repo. We recommend that you switch to another implementation and keep building beautiful, usable apps based on Material Design. Thanks for being part of the project!
+
 MDC React is the official implementation of Google's Material Design Components. It is a wrapper library for [MDC Web](https://github.com/material-components/material-components-web). Please refer to our [MDC Web Catalog](https://material-components.github.io/material-components-web-catalog/#/) to play and interact with the Components.
 
 ![mpmgq9h6b9x](https://user-images.githubusercontent.com/579873/44939654-d8fdfd80-ad3b-11e8-9b64-6244cb5e6886.png)


### PR DESCRIPTION
See [Preview](https://github.com/material-components/material-components-web-react/blob/5e13c9dd97a3690b697a9d8cb911da4f54abdd01/README.md) here.